### PR TITLE
fix(automation): harden cronjob writes and sync core memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,14 @@ Data pipeline importing Claude Code usage analytics into ClickHouse and DuckDB.
 
 TypeScript + Bun. Python removed. Single `ccusage_events` table.
 
+Docs index: `docs/INDEX.md` (core memory: `docs/knowledge/core-memory.md`).
+
 ## Commands
 
 ```bash
 bun test                # tests
 bunx tsc --noEmit       # typecheck (expect @types/bun errors)
+git log --since='<last-run-iso>' --pretty=format:'%H %cI %s' --name-only  # recent-change audit window
 rg -n "<symbol>" src tests -g '!**/*.test.ts'  # dead-code evidence (non-test refs)
 bun run src/scripts/import-all.ts --verbose  # full import
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,14 @@ TypeScript + Bun pipeline importing Claude Code usage analytics into ClickHouse 
 
 **Single table**: `ccusage_events`. All record types (daily, session, block, project_daily) in one flat table with model breakdowns exploded inline.
 
+Docs index: `docs/INDEX.md` (core memory: `docs/knowledge/core-memory.md`).
+
 ## Commands
 
 ```bash
 bun test                          # run tests
 bunx tsc --noEmit                 # typecheck
+git log --since='<last-run-iso>' --pretty=format:'%H %cI %s' --name-only  # recent-change audit window
 rg -n "<symbol>" src tests -g '!**/*.test.ts'  # dead-code evidence (non-test refs)
 bun run src/scripts/import-all.ts --verbose  # full import
 bun run src/scripts/backfill-duckdb.ts       # backfill DuckDB from ClickHouse

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,6 @@
+# Docs Index
+
+- `docs/knowledge/core-memory.md` — durable maintenance notes for automation runs.
+- `docs/schema.sql` — single-table ClickHouse schema.
+- `docs/migrate_add_source.sql` — migration adding `source`.
+- `docs/queries.sql` — common query snippets.

--- a/docs/archive/python/pyproject.toml
+++ b/docs/archive/python/pyproject.toml
@@ -3,7 +3,7 @@ name = "ccusage-import"
 version = "0.1.0"
 description = "Import ccusage data into ClickHouse for analytics"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "clickhouse-connect>=0.8.18",
     "python-dotenv>=1.0.1",
@@ -66,8 +66,8 @@ exclude = [
     "venv",
 ]
 
-# Target Python 3.8+ to match project requirements
-target-version = "py38"
+# Target Python 3.10+ to match dependency constraints
+target-version = "py310"
 
 [tool.ruff.lint.per-file-ignores]
 # Allow unused imports in __init__.py files

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -1,0 +1,22 @@
+# Core Memory
+
+Small durable notes for ongoing maintenance automation.
+
+## Scan scope commands
+
+```bash
+git log --since='<last-run-iso>' --pretty=format:'%H %cI %s' --name-only
+git log --since='7 days ago' --pretty=format:'%h %cI %s'
+rg -n "<symbol>" src tests -g '!**/*.test.ts' -g '!**/*.spec.ts'
+```
+
+## Known guardrails
+
+- `run-import.sh` is Bun-only; do not add npm/yarn fallback.
+- `src/scripts/setup-cronjob.ts` must write crontab via stdin (`crontab -`), not shell-quoted `echo`.
+- Keep sink dedup delete filters SQL-escaped in both ClickHouse and DuckDB sinks.
+
+## CI and archived Python docs
+
+- `docs/archive/python/pyproject.toml` should keep `requires-python` aligned with dependency floors to avoid Dependabot security-update resolution failures.
+- If that archived lockfile churn is not needed, consider disabling that Dependabot ecosystem in repo settings/config.

--- a/src/scripts/setup-cronjob.ts
+++ b/src/scripts/setup-cronjob.ts
@@ -29,11 +29,6 @@ interface Options {
   help?: boolean;
 }
 
-interface CronEntry {
-  schedule: string;
-  command: string;
-}
-
 // Constants
 const PROJECT_DIR = path.resolve(__dirname, '..', '..');
 const LOG_DIR = path.join(PROJECT_DIR, 'logs');
@@ -48,7 +43,6 @@ const colors = {
   green: '\x1b[32m',
   yellow: '\x1b[33m',
   blue: '\x1b[34m',
-  dim: '\x1b[2m',
 };
 
 function log(color: string, emoji: string, message: string) {
@@ -126,8 +120,8 @@ function getCrontab(): string[] {
  * Set crontab entries
  */
 function setCrontab(entries: string[]): void {
-  const content = entries.join('\n');
-  execSync(`echo '${content}' | crontab -`, { stdio: 'pipe' });
+  const content = `${entries.join('\n')}\n`;
+  execSync('crontab -', { input: content, stdio: ['pipe', 'ignore', 'pipe'] });
 }
 
 /**

--- a/src/scripts/setup-cronjob.ts
+++ b/src/scripts/setup-cronjob.ts
@@ -120,8 +120,21 @@ function getCrontab(): string[] {
  * Set crontab entries
  */
 function setCrontab(entries: string[]): void {
+  if (entries.length === 0) {
+    throw new Error('Refusing to install an empty crontab');
+  }
+
   const content = `${entries.join('\n')}\n`;
-  execSync('crontab -', { input: content, stdio: ['pipe', 'ignore', 'pipe'] });
+  try {
+    execSync('crontab -', { input: content, stdio: ['pipe', 'ignore', 'pipe'] });
+  } catch (error) {
+    const stderr =
+      typeof error === 'object' && error !== null && 'stderr' in error
+        ? String((error as { stderr?: unknown }).stderr ?? '').trim()
+        : '';
+    const suffix = stderr ? `: ${stderr}` : '';
+    throw new Error(`Failed to install crontab entries${suffix}`);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- harden cronjob installation by writing crontab content via stdin (crontab -) instead of shell-quoted echo
- remove zero-reference dead code in setup-cronjob.ts (CronEntry, colors.dim)
- add durable docs memory surfaces (docs/knowledge/core-memory.md, docs/INDEX.md) and reference them from AGENTS.md and CLAUDE.md
- align archived Python metadata (requires-python >=3.10, ruff target-version=py310) with dependency floors shown by Dependabot security-update failures

## Verification
- bun test
- bun run src/scripts/setup-cronjob.ts -h
- rg -n "\\bCronEntry\\b|\\bdim\\b" src/scripts/setup-cronjob.ts src -g '!**/*.test.ts' -g '!**/*.spec.ts' (no matches)

## Evidence
- Dependabot dynamic run failure: https://github.com/duyet/ccusage-import/actions/runs/25760658405
- failure log indicates unsatisfiable Python floor (requires-python >=3.8) against updated dependency minimums (python-dotenv/pytest/urllib3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a docs index linking core reference and maintenance guides
  * Expanded agent/assistant docs with a post-typecheck audit command (git log) in the commands list

* **Chores**
  * Raised archived Python components' minimum Python requirement to 3.10

* **Refactor**
  * Simplified and made the cronjob setup installation stricter and more robust

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/ccusage-import/pull/38)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->