### PR TITLE
fix(automation): remove TS6 baseUrl deprecation and sync runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@ Docs index: `docs/INDEX.md` (core memory: `docs/knowledge/core-memory.md`).
 
 ```bash
 bun test                # tests
-bunx tsc --noEmit       # typecheck (expect @types/bun errors)
+bunx tsc --noEmit       # typecheck
+BUN_TMPDIR="$PWD/.tmp/bun-tmp" BUN_INSTALL_CACHE_DIR="$PWD/.tmp/bun-install-cache" bunx tsc --noEmit  # fallback in restricted tempdir envs
 git log --since='<last-run-iso>' --pretty=format:'%H %cI %s' --name-only  # recent-change audit window
 rg -n "<symbol>" src tests -g '!**/*.test.ts'  # dead-code evidence (non-test refs)
 bun run src/scripts/import-all.ts --verbose  # full import

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Docs index: `docs/INDEX.md` (core memory: `docs/knowledge/core-memory.md`).
 ```bash
 bun test                          # run tests
 bunx tsc --noEmit                 # typecheck
+BUN_TMPDIR="$PWD/.tmp/bun-tmp" BUN_INSTALL_CACHE_DIR="$PWD/.tmp/bun-install-cache" bunx tsc --noEmit  # fallback in restricted tempdir envs
 git log --since='<last-run-iso>' --pretty=format:'%H %cI %s' --name-only  # recent-change audit window
 rg -n "<symbol>" src tests -g '!**/*.test.ts'  # dead-code evidence (non-test refs)
 bun run src/scripts/import-all.ts --verbose  # full import

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -17,6 +17,8 @@ rg -n "<symbol>" src tests -g '!**/*.test.ts' -g '!**/*.spec.ts'
 - Keep sink dedup delete filters SQL-escaped in both ClickHouse and DuckDB sinks.
 - Companion (`codex`/`opencode`) totals must avoid cache double-count: `total_tokens = inputTokens + outputTokens`.
 - Claude totals must keep cache components separate: `total_tokens = input + output + cacheCreation + cacheRead`.
+- TypeScript 6: avoid `baseUrl` in `tsconfig.json`; keep path aliases with explicit `./src/...` prefixes.
+- In restricted environments where Bun cannot write temp files, run checks with `BUN_TMPDIR="$PWD/.tmp/bun-tmp"` and `BUN_INSTALL_CACHE_DIR="$PWD/.tmp/bun-install-cache"`.
 
 ## Routine operations
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,15 +43,14 @@
     "jsxImportSource": "react",
 
     // Path Aliases
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "@/config/*": ["src/config/*"],
-      "@/database/*": ["src/database/*"],
-      "@/fetchers/*": ["src/fetchers/*"],
-      "@/parsers/*": ["src/parsers/*"],
-      "@/ui/*": ["src/ui/*"],
-      "@/utils/*": ["src/utils/*"]
+      "@/*": ["./src/*"],
+      "@/config/*": ["./src/config/*"],
+      "@/database/*": ["./src/database/*"],
+      "@/fetchers/*": ["./src/fetchers/*"],
+      "@/parsers/*": ["./src/parsers/*"],
+      "@/ui/*": ["./src/ui/*"],
+      "@/utils/*": ["./src/utils/*"]
     },
 
     // Completeness


### PR DESCRIPTION
## Summary
- remove deprecated `baseUrl` usage from `tsconfig.json` and keep alias behavior with explicit `./src/...` path mappings
- sync `AGENTS.md`, `CLAUDE.md`, and `docs/knowledge/core-memory.md` with the validated Bun tempdir/cache fallback command for restricted environments
- keep scope surgical to automation-maintenance findings only

## Evidence from recent changes
- Commit since last run (`2026-05-13T21:00:54Z`) in this repo was docs-only: `5e105737b926ba1a317d2fbc6d080959fba41ce6`
- TypeScript 6 deprecation surfaced locally before patch: `TS5101 Option 'baseUrl' is deprecated`
- After patch, that deprecation no longer appears (`rg 'TS5101|baseUrl'` on typecheck output returns no hits)

## Validation
- `bun test` (pass: 85 tests)
- `BUN_TMPDIR="$PWD/.tmp/bun-tmp" BUN_INSTALL_CACHE_DIR="$PWD/.tmp/bun-install-cache" bunx tsc --noEmit`
  - still fails with pre-existing Bun/Node ambient type issues (outside this patch scope)
  - specific TS6 `baseUrl` deprecation error is resolved

## Dead code check notes
- No zero-reference symbols found in recently modified runtime files:
  - `buildCompanionEventRows` referenced by `src/sources/companion.ts`
  - `setCrontab` and `buildCronEntry` referenced in `src/scripts/setup-cronjob.ts`
  - SQL escaping helpers referenced by both sinks

## Documentation hygiene
- No dated AI-generated `code-smell/dead-code` docs found in this repo to migrate.
