### PR TITLE
fix(tooling): restore bun types and sync runbook commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,12 @@ Docs index: `docs/INDEX.md` (core memory: `docs/knowledge/core-memory.md`).
 ## Commands
 
 ```bash
+bun install --frozen-lockfile  # install deps in fresh worktree before checks
 bun test                # tests
 bunx tsc --noEmit       # typecheck
 BUN_TMPDIR="$PWD/.tmp/bun-tmp" BUN_INSTALL_CACHE_DIR="$PWD/.tmp/bun-install-cache" bunx tsc --noEmit  # fallback in restricted tempdir envs
 git log --since='<last-run-iso>' --pretty=format:'%H %cI %s' --name-only  # recent-change audit window
-rg -n "<symbol>" src tests -g '!**/*.test.ts'  # dead-code evidence (non-test refs)
+rg -n "<symbol>" src tests -g '!**/*.test.ts' -g '!**/*.spec.ts'  # dead-code evidence (non-test refs)
 bun run src/scripts/import-all.ts --verbose  # full import
 bun run src/scripts/backfill-duckdb.ts       # backfill DuckDB from ClickHouse
 git log --since='7 days ago' --name-only --pretty=format:'--- %h %ad %s' --date=short

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,11 +11,12 @@ Docs index: `docs/INDEX.md` (core memory: `docs/knowledge/core-memory.md`).
 ## Commands
 
 ```bash
+bun install --frozen-lockfile        # install deps in fresh worktree before checks
 bun test                          # run tests
 bunx tsc --noEmit                 # typecheck
 BUN_TMPDIR="$PWD/.tmp/bun-tmp" BUN_INSTALL_CACHE_DIR="$PWD/.tmp/bun-install-cache" bunx tsc --noEmit  # fallback in restricted tempdir envs
 git log --since='<last-run-iso>' --pretty=format:'%H %cI %s' --name-only  # recent-change audit window
-rg -n "<symbol>" src tests -g '!**/*.test.ts'  # dead-code evidence (non-test refs)
+rg -n "<symbol>" src tests -g '!**/*.test.ts' -g '!**/*.spec.ts'  # dead-code evidence (non-test refs)
 bun run src/scripts/import-all.ts --verbose  # full import
 bun run src/scripts/backfill-duckdb.ts       # backfill DuckDB from ClickHouse
 git log --since='7 days ago' --name-only --pretty=format:'--- %h %ad %s' --date=short

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -5,6 +5,7 @@ Small durable notes for ongoing maintenance automation.
 ## Scan scope commands
 
 ```bash
+bun install --frozen-lockfile
 git log --since='<last-run-iso>' --pretty=format:'%H %cI %s' --name-only
 git log --since='7 days ago' --pretty=format:'%h %cI %s'
 rg -n "<symbol>" src tests -g '!**/*.test.ts' -g '!**/*.spec.ts'
@@ -18,6 +19,7 @@ rg -n "<symbol>" src tests -g '!**/*.test.ts' -g '!**/*.spec.ts'
 - Companion (`codex`/`opencode`) totals must avoid cache double-count: `total_tokens = inputTokens + outputTokens`.
 - Claude totals must keep cache components separate: `total_tokens = input + output + cacheCreation + cacheRead`.
 - TypeScript 6: avoid `baseUrl` in `tsconfig.json`; keep path aliases with explicit `./src/...` prefixes.
+- In fresh clones/worktrees without `node_modules`, run `bun install --frozen-lockfile` before `bunx tsc --noEmit` to avoid false missing-module/type errors.
 - In restricted environments where Bun cannot write temp files, run checks with `BUN_TMPDIR="$PWD/.tmp/bun-tmp"` and `BUN_INSTALL_CACHE_DIR="$PWD/.tmp/bun-install-cache"`.
 
 ## Routine operations

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "resolveJsonModule": true,
     "allowJs": true,
     "checkJs": false,
-    "types": [],
+    "types": ["bun", "node"],
 
     // Emit
     "declaration": true,


### PR DESCRIPTION
## Summary
- restore TypeScript runtime type context in `tsconfig.json` by setting `types` to `bun` and `node`
- sync AGENTS/CLAUDE/core-memory commands to include `bun install --frozen-lockfile` for fresh worktrees
- align dead-code evidence command examples to exclude both `*.test.ts` and `*.spec.ts`

## Evidence from this maintenance run
- recent runtime changes in the 7-day window had no zero-reference dead-code candidates in non-test files
- the concrete regression signal was `bunx tsc --noEmit` failing after fresh install due missing Bun/Node globals with `types: []`
- after this patch: `bunx tsc --noEmit` passes

## Validation
- `bun test` (85 passed)
- `bunx tsc --noEmit` (pass)

## Summary by Sourcery

Restore Bun/Node TypeScript type context and keep maintenance runbook commands in sync for fresh worktrees and dead-code scans.

Bug Fixes:
- Re-enable Bun and Node global typings in the TypeScript config to prevent missing-module/type errors during type checking.

Enhancements:
- Standardize maintenance command examples to run Bun install with a frozen lockfile before checks.
- Update dead-code search examples to consistently exclude both test and spec TypeScript files.

Documentation:
- Refresh AGENTS, CLAUDE, and core-memory documentation to reflect the updated Bun install and dead-code scanning practices.