### PR TITLE
docs(automation): add detached-head branch command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ bun install --frozen-lockfile  # install deps in fresh worktree before checks
 bun test                # tests
 bunx tsc --noEmit       # typecheck
 BUN_TMPDIR="$PWD/.tmp/bun-tmp" BUN_INSTALL_CACHE_DIR="$PWD/.tmp/bun-install-cache" bunx tsc --noEmit  # fallback in restricted tempdir envs
+git switch -c automation/<topic> origin/master  # create branch first when worktree is on detached HEAD
 git log --since='<last-run-iso>' --pretty=format:'%H %cI %s' --name-only  # recent-change audit window
 rg -n "<symbol>" src tests -g '!**/*.test.ts' -g '!**/*.spec.ts'  # dead-code evidence (non-test refs)
 bun run src/scripts/import-all.ts --verbose  # full import

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ bun install --frozen-lockfile        # install deps in fresh worktree before che
 bun test                          # run tests
 bunx tsc --noEmit                 # typecheck
 BUN_TMPDIR="$PWD/.tmp/bun-tmp" BUN_INSTALL_CACHE_DIR="$PWD/.tmp/bun-install-cache" bunx tsc --noEmit  # fallback in restricted tempdir envs
+git switch -c automation/<topic> origin/master  # create branch first when worktree is on detached HEAD
 git log --since='<last-run-iso>' --pretty=format:'%H %cI %s' --name-only  # recent-change audit window
 rg -n "<symbol>" src tests -g '!**/*.test.ts' -g '!**/*.spec.ts'  # dead-code evidence (non-test refs)
 bun run src/scripts/import-all.ts --verbose  # full import

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -6,6 +6,7 @@ Small durable notes for ongoing maintenance automation.
 
 ```bash
 bun install --frozen-lockfile
+git switch -c automation/<topic> origin/master
 git log --since='<last-run-iso>' --pretty=format:'%H %cI %s' --name-only
 git log --since='7 days ago' --pretty=format:'%h %cI %s'
 rg -n "<symbol>" src tests -g '!**/*.test.ts' -g '!**/*.spec.ts'
@@ -21,6 +22,7 @@ rg -n "<symbol>" src tests -g '!**/*.test.ts' -g '!**/*.spec.ts'
 - TypeScript 6: avoid `baseUrl` in `tsconfig.json`; keep path aliases with explicit `./src/...` prefixes.
 - In fresh clones/worktrees without `node_modules`, run `bun install --frozen-lockfile` before `bunx tsc --noEmit` to avoid false missing-module/type errors.
 - In restricted environments where Bun cannot write temp files, run checks with `BUN_TMPDIR="$PWD/.tmp/bun-tmp"` and `BUN_INSTALL_CACHE_DIR="$PWD/.tmp/bun-install-cache"`.
+- In Codex worktrees that start on detached `HEAD`, create a branch from `origin/master` before making automation commits/PRs.
 
 ## Routine operations
 


### PR DESCRIPTION
## Summary
- audited commits since 2026-05-15T21:01:30Z and 7-day touched runtime files for smells/dead code
- found no actionable code smells, dead code, or regression evidence requiring runtime changes in this window
- synced runbook docs with one workflow command for detached-HEAD worktrees before PR work

## Changes
- AGENTS.md: add `git switch -c automation/<topic> origin/master` in command list
- CLAUDE.md: add the same command for parity
- docs/knowledge/core-memory.md: add the command + detached-HEAD guardrail note

## Evidence
- recent non-merge commit window: `8d33b5d73eaf74eabd4499bf11bafa63b7abd5be`
- dead-code search in touched runtime files produced no zero-reference candidates
- local checks: `bun test` (85 passed), `bunx tsc --noEmit` passed

## Notes
- no dated `docs/reviews/code-smell-dead-code-*.md` files exist in this repo; none created

## Summary by Sourcery

Documentation:
- Add a git switch command to AGENTS, CLAUDE, and core-memory docs for creating automation branches from origin/master when starting from a detached HEAD state.