### PR TITLE
docs(automation): add worktree lock fallback command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ bun test                # tests
 bunx tsc --noEmit       # typecheck
 BUN_TMPDIR="$PWD/.tmp/bun-tmp" BUN_INSTALL_CACHE_DIR="$PWD/.tmp/bun-install-cache" bunx tsc --noEmit  # fallback in restricted tempdir envs
 git switch -c automation/<topic> origin/master  # create branch first when worktree is on detached HEAD
+git worktree list --porcelain  # find owning worktree when .git/worktrees/.../*.lock errors appear
 git log --since='<last-run-iso>' --pretty=format:'%H %cI %s' --name-only  # recent-change audit window
 rg -n "<symbol>" src tests -g '!**/*.test.ts' -g '!**/*.spec.ts'  # dead-code evidence (non-test refs)
 bun run src/scripts/import-all.ts --verbose  # full import

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ bun test                          # run tests
 bunx tsc --noEmit                 # typecheck
 BUN_TMPDIR="$PWD/.tmp/bun-tmp" BUN_INSTALL_CACHE_DIR="$PWD/.tmp/bun-install-cache" bunx tsc --noEmit  # fallback in restricted tempdir envs
 git switch -c automation/<topic> origin/master  # create branch first when worktree is on detached HEAD
+git worktree list --porcelain  # find owning worktree when .git/worktrees/.../*.lock errors appear
 git log --since='<last-run-iso>' --pretty=format:'%H %cI %s' --name-only  # recent-change audit window
 rg -n "<symbol>" src tests -g '!**/*.test.ts' -g '!**/*.spec.ts'  # dead-code evidence (non-test refs)
 bun run src/scripts/import-all.ts --verbose  # full import

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -7,6 +7,7 @@ Small durable notes for ongoing maintenance automation.
 ```bash
 bun install --frozen-lockfile
 git switch -c automation/<topic> origin/master
+git worktree list --porcelain
 git log --since='<last-run-iso>' --pretty=format:'%H %cI %s' --name-only
 git log --since='7 days ago' --pretty=format:'%h %cI %s'
 rg -n "<symbol>" src tests -g '!**/*.test.ts' -g '!**/*.spec.ts'
@@ -23,6 +24,7 @@ rg -n "<symbol>" src tests -g '!**/*.test.ts' -g '!**/*.spec.ts'
 - In fresh clones/worktrees without `node_modules`, run `bun install --frozen-lockfile` before `bunx tsc --noEmit` to avoid false missing-module/type errors.
 - In restricted environments where Bun cannot write temp files, run checks with `BUN_TMPDIR="$PWD/.tmp/bun-tmp"` and `BUN_INSTALL_CACHE_DIR="$PWD/.tmp/bun-install-cache"`.
 - In Codex worktrees that start on detached `HEAD`, create a branch from `origin/master` before making automation commits/PRs.
+- If git operations fail in a linked worktree with `.git/worktrees/.../*.lock` permission errors, run branch/fetch/push from the owning checkout identified by `git worktree list --porcelain`.
 
 ## Routine operations
 


### PR DESCRIPTION
## Summary
- scanned commits since last run (`2026-05-16T21:00:13Z`) and 7-day fallback window for code smells, dead code, likely bugs, and perf regression signals
- found no critical/warning code issues in runtime paths for the scan window; since-last-run commit was docs-only (`47e5258`)
- added a minimal workflow-memory note for linked worktree lock failures observed in this run (`index.lock`/`HEAD.lock` permission errors)

## Changes
- `AGENTS.md`: add `git worktree list --porcelain` command for worktree lock diagnosis
- `CLAUDE.md`: add the same command to keep docs synchronized
- `docs/knowledge/core-memory.md`: add command + guardrail for running git branch/fetch/push from owning checkout when linked-worktree lock errors appear

## Verification
- `bun test` (pass: 85)
- `bunx tsc --noEmit` (pass)

## Findings snapshot
- critical: none
- warning: none
- info: 1 docs-memory workflow update (non-functional)
- dead code: none confident in recently modified runtime files
- performance regressions: no measurement-backed regression evidence in the scanned commit window
