### PR TITLE
docs(automation): add no-merges scan command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ git log --since='<last-run-iso>' --pretty=format:'%H %cI %s' --name-only  # rece
 rg -n "<symbol>" src tests -g '!**/*.test.ts' -g '!**/*.spec.ts'  # dead-code evidence (non-test refs)
 bun run src/scripts/import-all.ts --verbose  # full import
 bun run src/scripts/backfill-duckdb.ts       # backfill DuckDB from ClickHouse
-git log --since='7 days ago' --name-only --pretty=format:'--- %h %ad %s' --date=short
+git log --since='7 days ago' --no-merges --name-only --pretty=format:'--- %h %ad %s' --date=short
 ```
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ git log --since='<last-run-iso>' --pretty=format:'%H %cI %s' --name-only  # rece
 rg -n "<symbol>" src tests -g '!**/*.test.ts' -g '!**/*.spec.ts'  # dead-code evidence (non-test refs)
 bun run src/scripts/import-all.ts --verbose  # full import
 bun run src/scripts/backfill-duckdb.ts       # backfill DuckDB from ClickHouse
-git log --since='7 days ago' --name-only --pretty=format:'--- %h %ad %s' --date=short
+git log --since='7 days ago' --no-merges --name-only --pretty=format:'--- %h %ad %s' --date=short
 ```
 
 ## Config

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -9,7 +9,7 @@ bun install --frozen-lockfile
 git switch -c automation/<topic> origin/master
 git worktree list --porcelain
 git log --since='<last-run-iso>' --pretty=format:'%H %cI %s' --name-only
-git log --since='7 days ago' --pretty=format:'%h %cI %s'
+git log --since='7 days ago' --no-merges --pretty=format:'%h %cI %s'
 rg -n "<symbol>" src tests -g '!**/*.test.ts' -g '!**/*.spec.ts'
 ```
 


### PR DESCRIPTION
## Summary
- align automation scan commands in AGENTS.md and CLAUDE.md to use --no-merges
- mirror the same command in durable core memory runbook
- keep behavior unchanged (docs-only)

## Evidence scanned
- commit window since 2026-05-17T21:01:50.705Z contains docs-only change (895a9ee)
- 7-day non-merge runtime files reviewed: src/parsers/parsers.ts, src/scripts/setup-cronjob.ts, src/pipeline/types.ts, src/sinks/clickhouse.ts, src/sinks/duckdb.ts, run-import.sh
- no confident dead-code candidates with zero non-test references in those files

## Verification
- bun test
- bunx tsc --noEmit
