### PR TITLE
fix(security): gitignore env backups and live credential files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,14 @@
 .env
-.env.local
+.env.*
 !.env.example
 .dev.vars
+.dev.vars.*
 !.dev.vars.example
+credentials.toml
+credentials.toml.*
+summa.credentials.toml
+summa.credentials.toml.*
+!**/examples/credentials.toml
 node_modules/
 dist/
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ credentials.toml
 credentials.toml.*
 summa.credentials.toml
 summa.credentials.toml.*
-!**/examples/credentials.toml
+!apps/cli/examples/credentials.toml
 node_modules/
 dist/
 .DS_Store

--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -1,4 +1,6 @@
 .dev.vars
+.dev.vars.*
+!.dev.vars.example
 .wrangler
 node_modules
 build/

--- a/apps/cli/examples/credentials.toml
+++ b/apps/cli/examples/credentials.toml
@@ -1,5 +1,5 @@
-# Secrets only — keep out of main config and out of git.
-# Place at ~/.config/summa/credentials.toml or ./credentials.toml
+# Example credentials template. Values are placeholders — never commit real tokens.
+# Copy to ~/.config/summa/credentials.toml or ./credentials.toml (gitignored).
 # Or set SUMMA_CREDENTIALS=/path/to/this/file
 
 clickhouse_password = "replace-me"

--- a/scripts/ci/validate-deploy.sh
+++ b/scripts/ci/validate-deploy.sh
@@ -213,6 +213,7 @@ must_ignore = [
     "credentials.toml",
     "credentials.toml.bak",
     "summa.credentials.toml",
+    "apps/other/examples/credentials.toml",
 ]
 must_not_ignore = [
     ".env.example",
@@ -233,7 +234,7 @@ tracked = subprocess.check_output(["git", "ls-files"], text=True).splitlines()
 
 def forbidden_tracked(path: str) -> bool:
     name = path.rsplit("/", 1)[-1]
-    under_examples = "/examples/" in f"/{path}" or path.startswith("examples/")
+    known_template = path == "apps/cli/examples/credentials.toml"
     if name == ".env":
         return True
     if name.startswith(".env.") and name != ".env.example":
@@ -244,7 +245,7 @@ def forbidden_tracked(path: str) -> bool:
         return True
     if name.endswith(".bak"):
         return True
-    if name in {"credentials.toml", "summa.credentials.toml"} and not under_examples:
+    if name in {"credentials.toml", "summa.credentials.toml"} and not known_template:
         return True
     return False
 

--- a/scripts/ci/validate-deploy.sh
+++ b/scripts/ci/validate-deploy.sh
@@ -190,3 +190,90 @@ ok "CI/release workflows pin -p summa-import"
 
 [[ -f apps/cli/README.md ]] || fail "apps/cli/README.md required for cargo package"
 ok "apps/cli README present for crates.io"
+
+python3 - <<'PY'
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+def ignored(path: str) -> bool:
+    return subprocess.run(
+        ["git", "check-ignore", "--no-index", "-q", path]
+    ).returncode == 0
+
+must_ignore = [
+    ".env",
+    ".env.bak",
+    ".env.local",
+    ".env.production",
+    ".env.backup",
+    ".dev.vars.bak",
+    "apps/api/.dev.vars.bak",
+    "credentials.toml",
+    "credentials.toml.bak",
+    "summa.credentials.toml",
+]
+must_not_ignore = [
+    ".env.example",
+    "apps/api/.dev.vars.example",
+    "apps/cli/examples/credentials.toml",
+]
+failed = False
+for path in must_ignore:
+    if not ignored(path):
+        print(f"FAIL: {path} must be gitignored", file=sys.stderr)
+        failed = True
+for path in must_not_ignore:
+    if ignored(path):
+        print(f"FAIL: {path} must remain trackable", file=sys.stderr)
+        failed = True
+
+tracked = subprocess.check_output(["git", "ls-files"], text=True).splitlines()
+
+def forbidden_tracked(path: str) -> bool:
+    name = path.rsplit("/", 1)[-1]
+    under_examples = "/examples/" in f"/{path}" or path.startswith("examples/")
+    if name == ".env":
+        return True
+    if name.startswith(".env.") and name != ".env.example":
+        return True
+    if name == ".dev.vars":
+        return True
+    if name.startswith(".dev.vars.") and name != ".dev.vars.example":
+        return True
+    if name.endswith(".bak"):
+        return True
+    if name in {"credentials.toml", "summa.credentials.toml"} and not under_examples:
+        return True
+    return False
+
+for path in tracked:
+    if forbidden_tracked(path):
+        print(f"FAIL: tracked secret-shaped path {path}", file=sys.stderr)
+        failed = True
+
+example = Path("apps/cli/examples/credentials.toml").read_text()
+if re.search(r"keep out of git", example, re.I):
+    print("FAIL: example credentials.toml must not say to keep the template out of git", file=sys.stderr)
+    failed = True
+placeholder = re.compile(
+    r"(?i)^(replace-me|change-me|changeme|change_me|.*[=]replace-me)$"
+)
+for i, line in enumerate(example.splitlines(), 1):
+    s = line.strip()
+    if not s or s.startswith("#") or "=" not in s:
+        continue
+    key, _, raw = s.partition("=")
+    val = raw.strip().strip('"').strip("'")
+    if not placeholder.match(val):
+        print(
+            f"FAIL: apps/cli/examples/credentials.toml:{i} key {key.strip()} is not a placeholder",
+            file=sys.stderr,
+        )
+        failed = True
+
+if failed:
+    sys.exit(1)
+print("ok: gitignore covers env/credential backups; example stays a placeholder template")
+PY


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #100.

## Problem
`.gitignore` only ignored `.env` and `.env.local`, so backup names like `.env.bak` could be staged with `git add -A`. The CLI also reads `./credentials.toml` and `./summa.credentials.toml`, and those live files were not ignored. `apps/cli/examples/credentials.toml` is a tracked template whose header previously said to keep it out of git.

## Fix
- Ignore `.env.*` and `.dev.vars.*` (covers `.env.bak` and other backups) while keeping `.env.example` / `.dev.vars.example` tracked.
- Ignore live `credentials.toml` / `summa.credentials.toml` (and `*.bak` variants). The only gitignore exception is `apps/cli/examples/credentials.toml`.
- Rewrite the example header so it is clearly a placeholder template, not a real secrets file.
- Add a `scripts/ci/validate-deploy.sh` check that gitignore covers the risky names, that other `examples/credentials.toml` paths stay ignored, and that no secret-shaped paths are tracked.

Related: #104 only widened `.env.*` / `.dev.vars.*`. This PR also covers live credential filenames, the example header, and a CI assertion.

## History / rotation
No git history rewrite (no force-push to `master`).

Checked with `git ls-files` and `git log --follow` on credential-shaped paths:

- `.env.bak` was **never tracked**.
- The only tracked env file is `.env.example`.
- `examples/credentials.toml` → `apps/cli/examples/credentials.toml` has only ever contained `replace-me` placeholders (including the commented cookie-shaped cursor session example). There is no confirmed leak of live ClickHouse / MotherDuck / telemetry / Cursor secrets in git.

**Rotation is not required based on git history.** Rotate ClickHouse, MotherDuck, telemetry, and Cursor credentials only if a *real* local secret (for example a machine-local `.env.bak` or `credentials.toml`) was pasted, uploaded, or otherwise exposed outside this repo. Do not commit or paste those values here.

## Verify
```
git check-ignore --no-index -q .env.bak              # ignored
git check-ignore --no-index -q credentials.toml      # ignored
git check-ignore --no-index -q .env.example          # not ignored
git ls-files --error-unmatch apps/cli/examples/credentials.toml
bash scripts/ci/validate-deploy.sh
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8934cd58-8b4f-4e0d-9f7b-2742b104be33?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8934cd58-8b4f-4e0d-9f7b-2742b104be33&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Harden repository secret handling by ignoring environment and credential artifacts and validating that only safe example templates are tracked.

Bug Fixes:
- Prevent environment files, backups, and live credential files from being accidentally tracked by Git.

Enhancements:
- Clarify that the CLI credentials file is a safe placeholder template and may remain tracked.
- Add validation to ensure sensitive path patterns stay ignored, templates remain trackable, and no secret-shaped files are committed.

CI:
- Extend deployment validation to enforce Git ignore coverage and placeholder-only credential templates.