### PR TITLE
fix(install): verify sha256 checksums before extract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
         HOME_DIR="$(mktemp -d)"
         mkdir -p "$WWW/beta"
         cp dist/summa-x86_64-unknown-linux-gnu.tar.gz "$WWW/beta/"
+        cp dist/summa-x86_64-unknown-linux-gnu.tar.gz.sha256 "$WWW/beta/"
         cp install.sh "$WWW/install.sh"
         python3 - "$WWW" "$PORTFILE" <<'PY' &
         import http.server, os, socketserver, sys
@@ -101,7 +102,8 @@ jobs:
             SUMMA_DOWNLOAD_BASE="http://127.0.0.1:${PORT}" \
             SUMMA_VERSION=beta \
             SUMMA_INSTALL_DIR="$INSTALL_DIR" \
-            bash
+            bash | tee /tmp/summa-install.log
+        grep -q 'checksum ok' /tmp/summa-install.log
         "$INSTALL_DIR/summa" --version
         "$INSTALL_DIR/summa" --help >/dev/null
 

--- a/apps/cli/src/script/update.rs
+++ b/apps/cli/src/script/update.rs
@@ -113,6 +113,66 @@ pub fn sha256_file(path: &Path) -> anyhow::Result<String> {
     Ok(sha256_hex(&bytes))
 }
 
+/// Path of the CI sidecar: `<archive>.tar.gz.sha256`.
+pub fn sha256_sidecar_path(archive: &Path) -> PathBuf {
+    let mut os = archive.as_os_str().to_os_string();
+    os.push(".sha256");
+    PathBuf::from(os)
+}
+
+pub fn sha256_sidecar_url(tarball_url: &str) -> String {
+    format!("{tarball_url}.sha256")
+}
+
+/// First field of a GNU `shasum -a 256` sidecar (`<hex>  dist/<asset>.tar.gz`).
+pub fn parse_sha256_sidecar(text: &str) -> anyhow::Result<String> {
+    let line = text
+        .lines()
+        .map(|l| l.trim().trim_end_matches('\r'))
+        .find(|l| !l.is_empty())
+        .ok_or_else(|| anyhow!("checksum file is empty"))?;
+    let hex = line
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    if hex.len() != 64 || !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        bail!("malformed checksum file: expected 64 hex chars (GNU shasum -a 256), got {hex:?}");
+    }
+    Ok(hex)
+}
+
+pub fn verify_sha256(path: &Path, expected: &str) -> anyhow::Result<()> {
+    let actual = sha256_file(path)?;
+    if !actual.eq_ignore_ascii_case(expected) {
+        bail!(
+            "checksum mismatch for {} (expected {}, got {}). Refusing to install.",
+            path.file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("archive"),
+            expected.to_ascii_lowercase(),
+            actual
+        );
+    }
+    Ok(())
+}
+
+fn verify_tarball_sidecar(tar: &Path) -> anyhow::Result<()> {
+    let sidecar = sha256_sidecar_path(tar);
+    if !sidecar.is_file() {
+        bail!(
+            "checksum not found at {}. CI publishes a .sha256 sidecar next to every tarball.",
+            sidecar.display()
+        );
+    }
+    let text = fs::read_to_string(&sidecar)
+        .with_context(|| format!("read {}", sidecar.display()))?;
+    let expected = parse_sha256_sidecar(&text)?;
+    verify_sha256(tar, &expected)?;
+    println!("update: checksum ok ({expected})");
+    Ok(())
+}
+
 /// Successful completed runs from a GitHub Actions workflow-runs JSON body.
 pub fn parse_successful_runs(json: &str) -> anyhow::Result<Vec<WorkflowRun>> {
     let v: serde_json::Value = serde_json::from_str(json).context("parse workflow runs json")?;
@@ -382,7 +442,8 @@ pub async fn run(args: UpdateArgs) -> anyhow::Result<()> {
     let tmp = tempfile::tempdir()?;
     let bin = match pending {
         PendingUpdate::Stable { rel } => {
-            let tarball = download_release_tarball(&client, &rel.tarball_url, tmp.path()).await?;
+            let tarball =
+                download_and_verify_release_tarball(&client, &rel.tarball_url, tmp.path()).await?;
             extract_summa_from_tarball(&tarball, tmp.path())?
         }
         PendingUpdate::Beta {
@@ -391,7 +452,8 @@ pub async fn run(args: UpdateArgs) -> anyhow::Result<()> {
             artifact_id,
         } => {
             if let (Some(_tag), Some(url)) = (&tag, &tarball_url) {
-                let tarball = download_release_tarball(&client, url, tmp.path()).await?;
+                let tarball =
+                    download_and_verify_release_tarball(&client, url, tmp.path()).await?;
                 extract_summa_from_tarball(&tarball, tmp.path())?
             } else {
                 let token = token.ok_or_else(|| {
@@ -566,6 +628,29 @@ async fn download_release_tarball(
     Ok(path)
 }
 
+async fn download_and_verify_release_tarball(
+    client: &reqwest::Client,
+    tarball_url: &str,
+    dest_dir: &Path,
+) -> anyhow::Result<PathBuf> {
+    let tarball = download_release_tarball(client, tarball_url, dest_dir).await?;
+    let sidecar_url = sha256_sidecar_url(tarball_url);
+    let sidecar_path = sha256_sidecar_path(&tarball);
+    let resp = client.get(&sidecar_url).send().await?;
+    let status = resp.status();
+    if !status.is_success() {
+        bail!(
+            "checksum not found at {sidecar_url} (HTTP {status}). CI publishes a .sha256 sidecar next to every tarball."
+        );
+    }
+    let text = resp.text().await?;
+    fs::write(&sidecar_path, &text)?;
+    let expected = parse_sha256_sidecar(&text)?;
+    verify_sha256(&tarball, &expected)?;
+    println!("update: checksum ok ({expected})");
+    Ok(tarball)
+}
+
 /// Throttle file: records the last auto-update check as unix millis.
 pub fn auto_update_marker_path() -> PathBuf {
     dirs::data_local_dir()
@@ -729,6 +814,7 @@ fn extract_summa_from_artifact_zip(zip_path: &Path, dest_dir: &Path) -> anyhow::
     }
     let tar = find_named(dest_dir, ".tar.gz")
         .ok_or_else(|| anyhow!("artifact zip did not contain a .tar.gz"))?;
+    verify_tarball_sidecar(&tar)?;
     extract_summa_from_tarball(&tar, dest_dir)
 }
 
@@ -859,6 +945,46 @@ mod tests {
         assert_eq!(
             sha256_hex(b"summa"),
             "b44233a2f7cd626f6e8ddce9939e127388251740504e4af932fb75066509fa44"
+        );
+    }
+
+    #[test]
+    fn parse_sha256_sidecar_gnu_shasum() {
+        let text = "3f97eacb7335bd7e91de18f5703050da387d88e12733b8c4f893105adc34489c  dist/summa-x86_64-unknown-linux-gnu.tar.gz\n";
+        assert_eq!(
+            parse_sha256_sidecar(text).unwrap(),
+            "3f97eacb7335bd7e91de18f5703050da387d88e12733b8c4f893105adc34489c"
+        );
+        let crlf =
+            "AABBCCDDEEFF00112233445566778899AABBCCDDEEFF00112233445566778899  file.tar.gz\r\n";
+        assert_eq!(
+            parse_sha256_sidecar(crlf).unwrap(),
+            "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+        );
+        assert!(parse_sha256_sidecar("").is_err());
+        assert!(parse_sha256_sidecar("not-a-hash  file.tar.gz\n").is_err());
+        assert!(parse_sha256_sidecar("abc  file\n").is_err());
+    }
+
+    #[test]
+    fn verify_sha256_match_and_mismatch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tar = tmp.path().join("summa-x86_64-unknown-linux-gnu.tar.gz");
+        std::fs::write(&tar, b"not-a-real-tar").unwrap();
+        let digest = sha256_file(&tar).unwrap();
+        let sidecar = format!("{digest}  dist/summa-x86_64-unknown-linux-gnu.tar.gz\n");
+        let expected = parse_sha256_sidecar(&sidecar).unwrap();
+        verify_sha256(&tar, &expected).unwrap();
+        let err = verify_sha256(&tar, &"0".repeat(64)).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("checksum mismatch"), "{msg}");
+        assert_eq!(
+            sha256_sidecar_path(&tar),
+            tar.with_file_name("summa-x86_64-unknown-linux-gnu.tar.gz.sha256")
+        );
+        assert_eq!(
+            sha256_sidecar_url("https://example/summa-x.tar.gz"),
+            "https://example/summa-x.tar.gz.sha256"
         );
     }
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,6 +1,6 @@
 # Docs Index
 
-- `install.sh` — `curl | bash` installer (`SUMMA_CHANNEL=beta|stable`; stable tarball, else rolling `beta`).
+- `install.sh` — `curl | bash` installer (`SUMMA_CHANNEL=beta|stable`; stable tarball, else rolling `beta`). Verifies the CI `.sha256` sidecar before extract.
 - `scripts/ci/validate-deploy.sh` — CI checks for install.sh, k8s, wrangler.jsonc, release-please.
 - `docs/install.md` — machine install, config, auto cron, telemetry hub.
 - `docs/telemetry.md` — hosted hub at summa.duyet.net. Rust Worker: `apps/api`.

--- a/docs/install.md
+++ b/docs/install.md
@@ -17,6 +17,8 @@ curl -fsSL https://summa.duyet.net/install.sh | SUMMA_SETUP_CRON=1 SUMMA_CRON_EV
 
 Env: `SUMMA_INSTALL_DIR`, `SUMMA_CHANNEL` (`beta` or `stable`), `SUMMA_VERSION` (a tag like `v0.1.1` overrides the channel), `SUMMA_DRY_RUN=1`, `SUMMA_TELEMETRY_TOKEN`. Switch channels and update with `summa update --beta|--stable`; enable auto-update with `summa config --set update.mode=auto`.
 
+CI publishes a GNU `shasum -a 256` sidecar next to every tarball (`summa-<target>.tar.gz.sha256`, first field is the digest; the filename is `dist/…`). `install.sh` and `summa update` download that sidecar, hash the archive, and **abort** if the sidecar is missing, malformed, or the digest does not match — then extract and replace the binary.
+
 ## 2. Config
 
 `~/.config/summa/config.toml` has no secrets. Tokens go in `credentials.toml`.

--- a/install.sh
+++ b/install.sh
@@ -37,6 +37,54 @@ need_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
 }
 
+need_sha256() {
+  if command -v sha256sum >/dev/null 2>&1 || command -v shasum >/dev/null 2>&1; then
+    return 0
+  fi
+  die "required command not found: sha256sum or shasum (needed to verify the release digest)"
+}
+
+# First field of a GNU `shasum -a 256` sidecar (`<hex>  dist/<asset>.tar.gz`).
+parse_sha256_sidecar() {
+  local sidecar="$1" hex
+  hex="$(tr -d '\r' < "$sidecar" | awk 'NF { print $1; exit }')"
+  hex="$(printf '%s' "$hex" | tr '[:upper:]' '[:lower:]')"
+  if [ "${#hex}" -ne 64 ]; then
+    die "malformed checksum file ${sidecar}: expected 64 hex chars (GNU shasum -a 256), got '${hex:-empty}'"
+  fi
+  case "$hex" in
+    *[!0-9a-f]*)
+      die "malformed checksum file ${sidecar}: expected 64 hex chars (GNU shasum -a 256), got '${hex}'"
+      ;;
+  esac
+  printf '%s\n' "$hex"
+}
+
+file_sha256() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  else
+    shasum -a 256 "$file" | awk '{print $1}'
+  fi | tr '[:upper:]' '[:lower:]'
+}
+
+# Sidecar names dist/<asset>.tar.gz; compare the hex only against the local archive.
+verify_archive() {
+  local archive="$1" sidecar="$2" label="$3"
+  local expected actual
+  [ -s "$sidecar" ] || die "checksum file empty (${sidecar}). CI publishes ${label}.sha256 next to every tarball."
+  expected="$(parse_sha256_sidecar "$sidecar")"
+  actual="$(file_sha256 "$archive")"
+  if [ -z "$actual" ]; then
+    die "failed to hash ${archive}"
+  fi
+  if [ "$actual" != "$expected" ]; then
+    die "checksum mismatch for ${label} (expected ${expected}, got ${actual}). Refusing to install."
+  fi
+  info "checksum ok (${actual})"
+}
+
 curl_get() {
   curl -fsSL -A "${USER_AGENT}" "$@"
 }
@@ -161,21 +209,24 @@ main() {
   need_cmd mkdir
   need_cmd tar
   need_cmd curl
+  need_sha256
 
-  local target asset url tmp found
+  local target asset url checksum_url tmp found
   target="$(detect_target)"
   asset="summa-${target}"
   VERSION="$(resolve_version "$asset")"
   url="$(asset_url "$VERSION" "$asset")"
+  checksum_url="${url}.sha256"
 
   info "summa installer"
   info "  version : ${VERSION}"
   info "  target  : ${target}"
   info "  install : ${INSTALL_DIR}/${BIN_NAME}"
   info "  url     : ${url}"
+  info "  checksum: ${checksum_url}"
 
   if [ "$DRY_RUN" = "1" ] || [ "$DRY_RUN" = "true" ]; then
-    info "dry-run: would download and install ${BIN_NAME} → ${INSTALL_DIR}"
+    info "dry-run: would download, verify sha256, and install ${BIN_NAME} → ${INSTALL_DIR}"
     mkdir -p "${INSTALL_DIR}"
     info "dry-run: install dir ready (${INSTALL_DIR})"
     exit 0
@@ -195,6 +246,11 @@ main() {
     warn "Do not cargo build --release on this machine."
     exit 1
   fi
+
+  if ! curl_get "$checksum_url" -o "${tmp}/summa.tar.gz.sha256"; then
+    die "checksum not found at ${checksum_url}. CI publishes a .sha256 sidecar next to every tarball; install will not proceed without it."
+  fi
+  verify_archive "${tmp}/summa.tar.gz" "${tmp}/summa.tar.gz.sha256" "${asset}.tar.gz"
 
   tar -xzf "${tmp}/summa.tar.gz" -C "${tmp}"
   found="$(find "${tmp}" -type f -name "${BIN_NAME}" -print)"

--- a/install.sh
+++ b/install.sh
@@ -247,7 +247,7 @@ main() {
     exit 1
   fi
 
-  if ! curl_get "$checksum_url" -o "${tmp}/summa.tar.gz.sha256"; then
+  if ! curl_get "$checksum_url" -o "${tmp}/summa.tar.gz.sha256" 2>/dev/null; then
     die "checksum not found at ${checksum_url}. CI publishes a .sha256 sidecar next to every tarball; install will not proceed without it."
   fi
   verify_archive "${tmp}/summa.tar.gz" "${tmp}/summa.tar.gz.sha256" "${asset}.tar.gz"

--- a/scripts/ci/validate-deploy.sh
+++ b/scripts/ci/validate-deploy.sh
@@ -45,6 +45,7 @@ out="$(
 printf '%s\n' "$out"
 echo "$out" | grep -q 'dry-run: would download' || fail "install.sh dry-run missing marker"
 echo "$out" | grep -q 'releases/download/v0.1.1/summa-' || fail "install.sh dry-run missing release URL"
+echo "$out" | grep -q '.tar.gz.sha256' || fail "install.sh dry-run missing checksum URL"
 echo "$out" | grep -Eq 'target +: +(x86_64|aarch64)-(unknown-linux-gnu|apple-darwin)' \
   || fail "install.sh dry-run missing platform target"
 [[ -d "$install_dir" ]] || fail "install.sh dry-run did not create install dir"
@@ -59,6 +60,20 @@ mkdir -p "$www/beta/${asset}"
 printf '#!/bin/sh\necho summa 0.0.0-ci\n' > "$www/beta/${asset}/summa"
 chmod +x "$www/beta/${asset}/summa"
 tar -C "$www/beta" -czf "$www/beta/${asset}.tar.gz" "$asset"
+# CI writes GNU `shasum -a 256` sidecars next to the archive.
+(
+  cd "$www/beta"
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${asset}.tar.gz" > "${asset}.tar.gz.sha256"
+  else
+    sha256sum "${asset}.tar.gz" > "${asset}.tar.gz.sha256"
+  fi
+)
+mkdir -p "$www/mismatch" "$www/nochecksum"
+cp "$www/beta/${asset}.tar.gz" "$www/mismatch/"
+cp "$www/beta/${asset}.tar.gz" "$www/nochecksum/"
+printf '%s  %s\n' "0000000000000000000000000000000000000000000000000000000000000000" "${asset}.tar.gz" \
+  > "$www/mismatch/${asset}.tar.gz.sha256"
 cp install.sh "$www/install.sh"
 portfile="$tmp/http.port"
 python3 - "$www" "$portfile" <<'PY' &
@@ -90,12 +105,54 @@ info_curl="$(
 )"
 printf '%s\n' "$info_curl"
 grep -q 'channel beta written' <<<"$info_curl" || fail "install.sh did not record update channel"
-kill "$http_pid" >/dev/null 2>&1 || true
-wait "$http_pid" >/dev/null 2>&1 || true
+grep -q 'checksum ok' <<<"$info_curl" || fail "install.sh did not verify sha256"
 [[ -x "$curl_bin/summa" ]] || fail "curl | bash did not install an executable"
 got="$("$curl_bin/summa")"
 [[ "$got" == "summa 0.0.0-ci" ]] || fail "installed stub printed: $got"
 ok "curl | bash install.sh"
+
+run_install() {
+  local version="$1" dest="$2"
+  env \
+    HOME="$tmp/home-${version}" \
+    SUMMA_DOWNLOAD_BASE="http://127.0.0.1:${port}" \
+    SUMMA_VERSION="$version" \
+    SUMMA_INSTALL_DIR="$dest" \
+    bash install.sh
+}
+
+mismatch_bin="$tmp/mismatch-bin"
+mkdir -p "$mismatch_bin" "$tmp/home-mismatch"
+mismatch_out=""
+mismatch_rc=0
+if mismatch_out="$(run_install mismatch "$mismatch_bin" 2>&1)"; then
+  mismatch_rc=0
+else
+  mismatch_rc=$?
+fi
+printf '%s\n' "$mismatch_out"
+[ "$mismatch_rc" -ne 0 ] || fail "install.sh accepted a mismatched checksum"
+grep -q 'checksum mismatch' <<<"$mismatch_out" || fail "mismatch error missing 'checksum mismatch'"
+[[ ! -x "$mismatch_bin/summa" ]] || fail "mismatch install left a binary"
+ok "install.sh checksum mismatch is fatal"
+
+nochecksum_bin="$tmp/nochecksum-bin"
+mkdir -p "$nochecksum_bin" "$tmp/home-nochecksum"
+nocheck_out=""
+nocheck_rc=0
+if nocheck_out="$(run_install nochecksum "$nochecksum_bin" 2>&1)"; then
+  nocheck_rc=0
+else
+  nocheck_rc=$?
+fi
+printf '%s\n' "$nocheck_out"
+[ "$nocheck_rc" -ne 0 ] || fail "install.sh accepted an archive with no checksum"
+grep -q 'checksum not found' <<<"$nocheck_out" || fail "missing-sidecar error missing 'checksum not found'"
+[[ ! -x "$nochecksum_bin/summa" ]] || fail "missing-checksum install left a binary"
+ok "install.sh missing checksum is fatal"
+
+kill "$http_pid" >/dev/null 2>&1 || true
+wait "$http_pid" >/dev/null 2>&1 || true
 
 python3 - <<'PY'
 from pathlib import Path
@@ -180,6 +237,7 @@ echo "$rel" | grep -qE 'package .* -p summa-import|-p summa-import' \
   || fail "release.yml cargo package must use -p summa-import"
 echo "$rel" | grep -q -- '--bin summa' || fail "release.yml must build --bin summa"
 echo "$rel" | grep -q 'tag_name: beta' || fail "release.yml must publish rolling beta channel binaries"
+echo "$rel" | grep -q '.tar.gz.sha256' || fail "release.yml must publish .sha256 sidecars"
 
 ci="$(cat .github/workflows/ci.yml)"
 echo "$ci" | grep -qE 'cargo test .* -p summa-import' || fail "ci.yml cargo test must use -p summa-import"

--- a/scripts/ci/validate-deploy.sh
+++ b/scripts/ci/validate-deploy.sh
@@ -69,11 +69,11 @@ tar -C "$www/beta" -czf "$www/beta/${asset}.tar.gz" "$asset"
     sha256sum "${asset}.tar.gz" > "${asset}.tar.gz.sha256"
   fi
 )
-mkdir -p "$www/mismatch" "$www/nochecksum"
-cp "$www/beta/${asset}.tar.gz" "$www/mismatch/"
-cp "$www/beta/${asset}.tar.gz" "$www/nochecksum/"
+mkdir -p "$www/mismatch/beta" "$www/nochecksum/beta"
+cp "$www/beta/${asset}.tar.gz" "$www/mismatch/beta/"
+cp "$www/beta/${asset}.tar.gz" "$www/nochecksum/beta/"
 printf '%s  %s\n' "0000000000000000000000000000000000000000000000000000000000000000" "${asset}.tar.gz" \
-  > "$www/mismatch/${asset}.tar.gz.sha256"
+  > "$www/mismatch/beta/${asset}.tar.gz.sha256"
 cp install.sh "$www/install.sh"
 portfile="$tmp/http.port"
 python3 - "$www" "$portfile" <<'PY' &
@@ -112,11 +112,11 @@ got="$("$curl_bin/summa")"
 ok "curl | bash install.sh"
 
 run_install() {
-  local version="$1" dest="$2"
+  local prefix="$1" dest="$2"
   env \
-    HOME="$tmp/home-${version}" \
-    SUMMA_DOWNLOAD_BASE="http://127.0.0.1:${port}" \
-    SUMMA_VERSION="$version" \
+    HOME="$tmp/home-${prefix}" \
+    SUMMA_DOWNLOAD_BASE="http://127.0.0.1:${port}/${prefix}" \
+    SUMMA_VERSION=beta \
     SUMMA_INSTALL_DIR="$dest" \
     bash install.sh
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #102.

## Problem

`install.sh` (and the GitHub-release path in `summa update`) downloaded CI tarballs and extracted them without checking the `.sha256` sidecar that `release.yml` / `ci.yml` already upload. The digest files were unused.

#105 on `fix/102-install-checksum` takes a warn-and-continue approach when the sidecar is missing. This PR fails closed instead: missing, malformed, or mismatched checksums abort before extract.

## Verification

CI format is GNU `shasum -a 256`:

```
<64-hex>  dist/summa-<target>.tar.gz
```

The installer does **not** run `sha256sum -c` against that filename (it points at `dist/…`). It parses the first field, hashes the downloaded archive (`sha256sum` or `shasum -a 256`), and compares.

Flow (fresh install and `summa update`):

1. Download the `.tar.gz` into a temp dir
2. Download `<tarball>.sha256` (same URL + `.sha256`; CI artifact zips already contain the sidecar)
3. Parse / hash / compare
4. Only then extract and replace the binary

Fatal errors (no silent skip):

- checksum not found at `<url>.sha256`
- malformed sidecar (not 64 hex chars)
- checksum mismatch (expected vs got)
- no `sha256sum` / `shasum` on PATH

## Tests

- `scripts/ci/validate-deploy.sh`: happy-path curl|bash with a real sidecar; mismatch is fatal; missing sidecar is fatal; dry-run prints the `.sha256` URL
- `.github/workflows/ci.yml` smoke test copies the sidecar and greps `checksum ok`
- `summa-import` unit tests for sidecar parsing (including the published `dist/…` layout) and match/mismatch

## Docs

`docs/install.md` and `docs/INDEX.md` describe the sidecar format and fail-closed behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9ca4301-ce17-4bd5-be4a-f59402fe2a2f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9ca4301-ce17-4bd5-be4a-f59402fe2a2f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Verify release archive checksums before extracting or replacing installed binaries.

New Features:
- Add fail-closed SHA-256 verification for release archives downloaded by the installer and GitHub-release updates before extraction.

Bug Fixes:
- Prevent installation or updates from proceeding when checksum sidecars are missing, malformed, unavailable, or do not match the downloaded archive.

Enhancements:
- Support parsing GNU shasum sidecars and hashing archives with either sha256sum or shasum.
- Expose checksum URLs and verification status in installer and update output.

CI:
- Extend CI and deployment validation to cover checksum publishing, successful verification, missing sidecars, and mismatched checksums.

Documentation:
- Document the checksum sidecar format and fail-closed installation behavior.

Tests:
- Add unit coverage for sidecar parsing and matching or mismatched archive digests.