### PR TITLE
fix(api): harden /v1/ingest 4xx paths; keep payload totals

### DIFF
--- a/apps/api/src/auth.rs
+++ b/apps/api/src/auth.rs
@@ -1,5 +1,5 @@
 use serde::Deserialize;
-use worker::{Env, Error, Request, Response, Result};
+use worker::{Env, Request, Response, Result};
 
 use crate::types::{new_id, sha256_hex, timing_safe_eq, TOKEN_PREFIX};
 
@@ -12,6 +12,12 @@ pub struct ApiKeyAuth {
 #[derive(Clone)]
 pub struct SessionAuth {
     pub account_id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthError {
+    Unauthorized,
+    Unavailable,
 }
 
 #[derive(Deserialize)]
@@ -33,16 +39,15 @@ struct ApiKeyRow {
     revoked_at: Option<String>,
 }
 
-pub fn extract_bearer(req: &Request) -> String {
-    if let Ok(Some(alt)) = req.headers().get("X-Summa-Token") {
-        let t = alt.trim();
-        if !t.is_empty() {
-            return t.to_string();
-        }
+pub fn token_from_headers(x_summa: Option<&str>, authorization: Option<&str>) -> String {
+    if let Some(t) = x_summa.map(str::trim).filter(|s| !s.is_empty()) {
+        return t.to_string();
     }
-    if let Ok(Some(h)) = req.headers().get("Authorization") {
-        let h = h.trim();
-        if let Some(t) = h.strip_prefix("Bearer ").or_else(|| h.strip_prefix("bearer ")) {
+    if let Some(h) = authorization.map(str::trim).filter(|s| !s.is_empty()) {
+        if let Some(t) = h
+            .strip_prefix("Bearer ")
+            .or_else(|| h.strip_prefix("bearer "))
+        {
             return t.trim().to_string();
         }
         return h.to_string();
@@ -50,27 +55,37 @@ pub fn extract_bearer(req: &Request) -> String {
     String::new()
 }
 
-fn unauthorized() -> Result<Response> {
-    Response::from_json(&serde_json::json!({"error": "unauthorized"}))
-        .map(|r| r.with_status(401))
+pub fn extract_bearer(req: &Request) -> String {
+    let x_summa = req.headers().get("X-Summa-Token").ok().flatten();
+    let authorization = req.headers().get("Authorization").ok().flatten();
+    token_from_headers(x_summa.as_deref(), authorization.as_deref())
 }
 
-pub async fn require_api_key(req: &Request, env: &Env) -> Result<ApiKeyAuth> {
+fn unauthorized() -> Result<Response> {
+    Response::from_json(&serde_json::json!({"error": "unauthorized"})).map(|r| r.with_status(401))
+}
+
+pub async fn require_api_key(
+    req: &Request,
+    env: &Env,
+) -> std::result::Result<ApiKeyAuth, AuthError> {
     let token = extract_bearer(req);
     if !token.starts_with(TOKEN_PREFIX) {
-        return Err(Error::RustError("unauthorized".into()));
+        return Err(AuthError::Unauthorized);
     }
     let hash = sha256_hex(&token);
-    let db = env.d1("DB")?;
+    let db = env.d1("DB").map_err(|_| AuthError::Unavailable)?;
     let row = db
         .prepare(
             "SELECT id, account_id, name, token_prefix, created_at, revoked_at FROM api_keys WHERE token_hash = ? AND revoked_at IS NULL",
         )
-        .bind(&[hash.into()])?
+        .bind(&[hash.into()])
+        .map_err(|_| AuthError::Unavailable)?
         .first::<ApiKeyRow>(None)
-        .await?;
+        .await
+        .map_err(|_| AuthError::Unavailable)?;
     let Some(row) = row else {
-        return Err(Error::RustError("unauthorized".into()));
+        return Err(AuthError::Unauthorized);
     };
     let _ = row.name;
     Ok(ApiKeyAuth {
@@ -79,33 +94,48 @@ pub async fn require_api_key(req: &Request, env: &Env) -> Result<ApiKeyAuth> {
     })
 }
 
-pub async fn require_session(req: &Request, env: &Env) -> Result<SessionAuth> {
+pub async fn require_session(
+    req: &Request,
+    env: &Env,
+) -> std::result::Result<SessionAuth, AuthError> {
     let token = extract_bearer(req);
     if token.is_empty() {
-        return Err(Error::RustError("unauthorized".into()));
+        return Err(AuthError::Unauthorized);
     }
     let bootstrap = opt_secret(env, "BOOTSTRAP_TOKEN");
     if !bootstrap.is_empty() && timing_safe_eq(&token, &bootstrap) {
-        let account = ensure_owner_account(env).await?;
+        let account = ensure_owner_account(env)
+            .await
+            .map_err(|_| AuthError::Unavailable)?;
         return Ok(SessionAuth {
             account_id: account.id,
         });
     }
     if let Some(clerk) = verify_clerk_me(&token, env).await {
-        let account = ensure_clerk_account(env, &clerk.0, &clerk.1).await?;
+        let account = ensure_clerk_account(env, &clerk.0, &clerk.1)
+            .await
+            .map_err(|_| AuthError::Unavailable)?;
         return Ok(SessionAuth {
             account_id: account.id,
         });
     }
-    Err(Error::RustError("unauthorized".into()))
+    Err(AuthError::Unauthorized)
 }
 
-pub fn auth_error_response(err: Error) -> Result<Response> {
-    let msg = err.to_string();
-    if msg.contains("unauthorized") {
-        unauthorized()
-    } else {
-        Response::from_json(&serde_json::json!({"error": msg})).map(|r| r.with_status(500))
+pub fn auth_error_status(err: AuthError) -> u16 {
+    match err {
+        AuthError::Unauthorized => 401,
+        AuthError::Unavailable => 503,
+    }
+}
+
+pub fn auth_error_response(err: AuthError) -> Result<Response> {
+    match err {
+        AuthError::Unauthorized => unauthorized(),
+        AuthError::Unavailable => Response::from_json(&serde_json::json!({
+            "error": "auth unavailable"
+        }))
+        .map(|r| r.with_status(auth_error_status(err))),
     }
 }
 
@@ -196,7 +226,11 @@ pub async fn is_owner_account(env: &Env, account_id: &str) -> Result<bool> {
     Ok(row.map(|r| r.id == account_id).unwrap_or(false))
 }
 
-pub async fn mint_api_key(env: &Env, account_id: &str, name: &str) -> Result<(String, String, String)> {
+pub async fn mint_api_key(
+    env: &Env,
+    account_id: &str,
+    name: &str,
+) -> Result<(String, String, String)> {
     let id = new_id();
     let mut raw = [0u8; 32];
     let _ = getrandom::fill(&mut raw);
@@ -258,9 +292,7 @@ pub async fn revoke_api_key(env: &Env, account_id: &str, key_id: &str) -> Result
     }
     let db = env.d1("DB")?;
     let existing = db
-        .prepare(
-            "SELECT id FROM api_keys WHERE id = ? AND account_id = ? AND revoked_at IS NULL",
-        )
+        .prepare("SELECT id FROM api_keys WHERE id = ? AND account_id = ? AND revoked_at IS NULL")
         .bind(&[key_id.into(), account_id.into()])?
         .first::<KeyId>(None)
         .await?;
@@ -288,7 +320,10 @@ async fn verify_clerk_me(token: &str, env: &Env) -> Option<(String, String)> {
     let mut init = worker::RequestInit::new();
     init.with_method(worker::Method::Get);
     init.with_headers(headers);
-    for url in ["https://api.clerk.com/v1/me", "https://api.clerk.com/v1/users/me"] {
+    for url in [
+        "https://api.clerk.com/v1/me",
+        "https://api.clerk.com/v1/users/me",
+    ] {
         let req = worker::Request::new_with_init(url, &init).ok()?;
         let mut resp = worker::Fetch::Request(req).send().await.ok()?;
         if resp.status_code() != 200 {
@@ -304,4 +339,32 @@ async fn verify_clerk_me(token: &str, env: &Env) -> Option<(String, String)> {
         return Some((id.to_string(), name.to_string()));
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_or_wrong_prefix_is_unauthorized() {
+        assert!(token_from_headers(None, None).is_empty());
+        assert!(!token_from_headers(Some("secret"), None).starts_with(TOKEN_PREFIX));
+        assert!(!token_from_headers(None, Some("Bearer secret")).starts_with(TOKEN_PREFIX));
+        assert_eq!(
+            token_from_headers(None, Some("Bearer summa_abc")),
+            "summa_abc"
+        );
+        assert_eq!(
+            token_from_headers(Some("summa_header"), Some("Bearer other")),
+            "summa_header"
+        );
+        assert_eq!(token_from_headers(None, Some("summa_raw")), "summa_raw");
+        assert!(token_from_headers(None, Some("Bearer summa_abc")).starts_with(TOKEN_PREFIX));
+    }
+
+    #[test]
+    fn auth_failures_are_not_500() {
+        assert_eq!(auth_error_status(AuthError::Unauthorized), 401);
+        assert_eq!(auth_error_status(AuthError::Unavailable), 503);
+    }
 }

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -14,7 +14,7 @@ use auth::{
 use sinks::{collect_pings, fanout_write};
 use types::{
     ch_now, cors_allow_origin, ingest_body_too_large, ingest_status_code, ping_ok,
-    sanitize_event, stamp_ingest_identity, IngestBody, MAX_INGEST_EVENTS, VERSION,
+    stamp_ingest_identity, IngestParseError, VERSION,
 };
 
 #[event(fetch)]
@@ -24,10 +24,7 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
     if method == Method::Options {
         return apply_cors(origin.as_deref(), true, Response::empty()?.with_status(204));
     }
-    let public = matches!(
-        req.path().as_str(),
-        "/" | "/health" | "/install.sh"
-    );
+    let public = matches!(req.path().as_str(), "/" | "/health" | "/install.sh");
     match route(req, env).await {
         Ok(res) => apply_cors(origin.as_deref(), public, res),
         Err(_) => {
@@ -106,33 +103,36 @@ async fn ingest(mut req: Request, env: Env) -> Result<Response> {
         }))
         .map(|r| r.with_status(413));
     }
-    let body: IngestBody = match req.json().await {
+    let bytes = match req.bytes().await {
         Ok(b) => b,
         Err(_) => {
-            return Response::from_json(&serde_json::json!({"error": "invalid json"}))
+            return Response::from_json(&serde_json::json!({"error": "invalid body"}))
                 .map(|r| r.with_status(400));
         }
     };
-    if body.events.len() > MAX_INGEST_EVENTS {
-        return Response::from_json(&serde_json::json!({
-            "error": "too many events",
-            "max": MAX_INGEST_EVENTS,
-        }))
-        .map(|r| r.with_status(413));
-    }
+    let parsed = match types::parse_ingest_bytes(&bytes) {
+        Ok(p) => p,
+        Err(e) => {
+            let mut body = serde_json::json!({ "error": e.message() });
+            if e == IngestParseError::TooLarge {
+                body["max_bytes"] = types::MAX_INGEST_BYTES.into();
+            }
+            if e == IngestParseError::TooManyEvents {
+                body["max"] = types::MAX_INGEST_EVENTS.into();
+            }
+            return Response::from_json(&body).map(|r| r.with_status(e.status()));
+        }
+    };
     let now = ch_now();
-    let mut events = Vec::new();
-    for e in body.events {
-        let Some(mut e) = sanitize_event(e) else {
-            continue;
-        };
-        stamp_ingest_identity(&mut e, &auth.account_id, &auth.api_key_id, &now);
-        events.push(e);
+    let mut events = parsed.events;
+    for e in &mut events {
+        stamp_ingest_identity(e, &auth.account_id, &auth.api_key_id, &now);
     }
     let sinks = fanout_write(&env, &events).await;
     let code = ingest_status_code(&sinks);
     let res = Response::from_json(&serde_json::json!({
         "accepted": events.len(),
+        "rejected": parsed.rejected,
         "sinks": sinks,
     }))?;
     Ok(res.with_status(code))
@@ -161,15 +161,31 @@ async fn analytics(req: Request, env: Env, summary: bool) -> Result<Response> {
         .query_pairs()
         .find(|(k, _)| k == "until")
         .map(|(_, v)| v.into_owned());
-    let default_days = if summary { Some(days.unwrap_or(7)) } else { days };
+    let default_days = if summary {
+        Some(days.unwrap_or(7))
+    } else {
+        days
+    };
     let (since, until) = match analytics_window(since.as_deref(), until.as_deref(), default_days) {
         Ok(w) => w,
         Err(e) => {
-            return Response::from_json(&serde_json::json!({"error": e})).map(|r| r.with_status(400));
+            return Response::from_json(&serde_json::json!({"error": e}))
+                .map(|r| r.with_status(400));
         }
     };
-    let include_legacy = is_owner_account(&env, &auth.account_id).await.unwrap_or(false);
-    let points = match load_points(&env, &auth.account_id, include_legacy, &group, &since, &until).await {
+    let include_legacy = is_owner_account(&env, &auth.account_id)
+        .await
+        .unwrap_or(false);
+    let points = match load_points(
+        &env,
+        &auth.account_id,
+        include_legacy,
+        &group,
+        &since,
+        &until,
+    )
+    .await
+    {
         Ok(p) => p,
         Err(_) => {
             return Response::from_json(&serde_json::json!({"error": "analytics unavailable"}))
@@ -198,11 +214,7 @@ async fn create_key(mut req: Request, env: Env) -> Result<Response> {
         Ok(a) => a,
         Err(e) => return auth_error_response(e),
     };
-    let name = req
-        .json::<KeyName>()
-        .await
-        .unwrap_or_default()
-        .name;
+    let name = req.json::<KeyName>().await.unwrap_or_default().name;
     let (id, token, prefix) = mint_api_key(&env, &auth.account_id, &name).await?;
     Response::from_json(&serde_json::json!({ "id": id, "token": token, "prefix": prefix }))
 }

--- a/apps/api/src/types.rs
+++ b/apps/api/src/types.rs
@@ -72,12 +72,6 @@ pub struct EventRow {
     pub updated_at: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IngestBody {
-    #[serde(default)]
-    pub events: Vec<EventRow>,
-}
-
 #[derive(Debug, Clone, Serialize)]
 pub struct SinkAck {
     pub name: String,
@@ -134,6 +128,240 @@ pub fn ingest_body_too_large(content_length: Option<&str>) -> bool {
         .unwrap_or(false)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IngestParseError {
+    InvalidJson,
+    EventsNotArray,
+    TooLarge,
+    TooManyEvents,
+}
+
+impl IngestParseError {
+    pub fn status(self) -> u16 {
+        match self {
+            Self::InvalidJson | Self::EventsNotArray => 400,
+            Self::TooLarge | Self::TooManyEvents => 413,
+        }
+    }
+
+    pub fn message(self) -> &'static str {
+        match self {
+            Self::InvalidJson => "invalid json",
+            Self::EventsNotArray => "events must be an array",
+            Self::TooLarge => "payload too large",
+            Self::TooManyEvents => "too many events",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ParsedIngest {
+    pub events: Vec<EventRow>,
+    pub rejected: usize,
+}
+
+/// Parse `/v1/ingest` from raw bytes with `serde_json`.
+///
+/// Worker `Request::json` uses `serde_wasm_bindgen` (JS numbers are f64), which
+/// rejects `u64` token fields and `null` strings as a hard error for the whole
+/// body. One bad row must not 500 or drop a 400-event chunk.
+pub fn parse_ingest_bytes(bytes: &[u8]) -> std::result::Result<ParsedIngest, IngestParseError> {
+    if bytes.len() as u64 > MAX_INGEST_BYTES {
+        return Err(IngestParseError::TooLarge);
+    }
+    let v: serde_json::Value =
+        serde_json::from_slice(bytes).map_err(|_| IngestParseError::InvalidJson)?;
+    let Some(obj) = v.as_object() else {
+        return Err(IngestParseError::InvalidJson);
+    };
+    let arr = match obj.get("events") {
+        None => return Ok(ParsedIngest::default()),
+        Some(serde_json::Value::Array(arr)) => arr,
+        Some(_) => return Err(IngestParseError::EventsNotArray),
+    };
+    if arr.len() > MAX_INGEST_EVENTS {
+        return Err(IngestParseError::TooManyEvents);
+    }
+    let mut events = Vec::new();
+    let mut rejected = 0;
+    for item in arr {
+        match event_from_json(item).and_then(sanitize_event) {
+            Some(row) => events.push(row),
+            None => rejected += 1,
+        }
+    }
+    Ok(ParsedIngest { events, rejected })
+}
+
+pub fn event_from_json(v: &serde_json::Value) -> Option<EventRow> {
+    if !v.is_object() {
+        return None;
+    }
+    Some(EventRow {
+        date: json_string(v, &["date"]),
+        record_type: json_string(v, &["record_type", "recordType"]),
+        record_key: json_string(v, &["record_key", "recordKey"]),
+        source: json_string(v, &["source"]),
+        machine_name: json_string(v, &["machine_name", "machineName"]),
+        account_id: json_string(v, &["account_id", "accountId"]),
+        api_key_id: json_string(v, &["api_key_id", "apiKeyId"]),
+        model_name: json_string(v, &["model_name", "modelName"]),
+        session_id: json_string(v, &["session_id", "sessionId"]),
+        project_path: json_string(v, &["project_path", "projectPath"]),
+        input_tokens: json_u64(v, &["input_tokens", "inputTokens"]),
+        output_tokens: json_u64(v, &["output_tokens", "outputTokens"]),
+        cache_creation_tokens: json_u64(
+            v,
+            &[
+                "cache_creation_tokens",
+                "cacheCreationTokens",
+                "cacheCreationInputTokens",
+            ],
+        ),
+        cache_read_tokens: json_u64(
+            v,
+            &[
+                "cache_read_tokens",
+                "cacheReadTokens",
+                "cacheReadInputTokens",
+                "cachedInputTokens",
+            ],
+        ),
+        reasoning_tokens: json_u64(v, &["reasoning_tokens", "reasoningTokens"]),
+        total_tokens: json_u64(v, &["total_tokens", "totalTokens"]),
+        cost: json_f64(v, &["cost", "totalCost", "total_cost", "costUSD"]),
+        dedup_key: json_string(v, &["dedup_key", "dedupKey"]),
+        import_id: json_string(v, &["import_id", "importId"]),
+        block_id: json_string(v, &["block_id", "blockId"]),
+        start_time: json_opt_ts(v, &["start_time", "startTime"]),
+        end_time: json_opt_ts(v, &["end_time", "endTime"]),
+        actual_end_time: json_opt_ts(v, &["actual_end_time", "actualEndTime"]),
+        is_active: json_flag(v, &["is_active", "isActive"]),
+        is_gap: json_flag(v, &["is_gap", "isGap"]),
+        entries: json_u64(v, &["entries"]).min(u32::MAX as u64) as u32,
+        burn_rate: json_f64(v, &["burn_rate", "burnRate"]),
+        projection: json_f64(v, &["projection"]),
+        usage_limit_reset_time: json_opt_ts(v, &["usage_limit_reset_time", "usageLimitResetTime"]),
+        created_at: json_string(v, &["created_at", "createdAt"]),
+        updated_at: json_string(v, &["updated_at", "updatedAt"]),
+    })
+}
+
+fn json_string(v: &serde_json::Value, keys: &[&str]) -> String {
+    for key in keys {
+        match v.get(*key) {
+            Some(serde_json::Value::String(s)) => return s.clone(),
+            Some(serde_json::Value::Null) | None => continue,
+            Some(_) => continue,
+        }
+    }
+    String::new()
+}
+
+fn json_u64(v: &serde_json::Value, keys: &[&str]) -> u64 {
+    for key in keys {
+        let Some(x) = v.get(*key) else {
+            continue;
+        };
+        if let Some(n) = value_as_u64(x) {
+            return n;
+        }
+    }
+    0
+}
+
+fn json_f64(v: &serde_json::Value, keys: &[&str]) -> f64 {
+    for key in keys {
+        let Some(x) = v.get(*key) else {
+            continue;
+        };
+        if let Some(n) = value_as_f64(x) {
+            return n;
+        }
+    }
+    0.0
+}
+
+fn json_flag(v: &serde_json::Value, keys: &[&str]) -> u8 {
+    for key in keys {
+        match v.get(*key) {
+            Some(serde_json::Value::Bool(true)) => return 1,
+            Some(serde_json::Value::Bool(false)) => return 0,
+            Some(x) => {
+                if let Some(n) = value_as_u64(x) {
+                    return u8::from(n > 0);
+                }
+            }
+            None => continue,
+        }
+    }
+    0
+}
+
+fn json_opt_ts(v: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    let s = json_string(v, keys);
+    sanitize_ts(Some(s))
+}
+
+fn value_as_u64(x: &serde_json::Value) -> Option<u64> {
+    if x.is_null() {
+        return None;
+    }
+    if let Some(n) = x.as_u64() {
+        return Some(n);
+    }
+    if let Some(n) = x.as_i64() {
+        return Some(n.max(0) as u64);
+    }
+    if let Some(n) = x.as_f64() {
+        if n.is_finite() && n >= 0.0 {
+            return Some(n.trunc() as u64);
+        }
+        return Some(0);
+    }
+    if let Some(s) = x.as_str() {
+        let s = s.trim();
+        if s.is_empty() {
+            return None;
+        }
+        if let Ok(n) = s.parse::<u64>() {
+            return Some(n);
+        }
+        if let Ok(n) = s.parse::<f64>() {
+            if n.is_finite() && n >= 0.0 {
+                return Some(n.trunc() as u64);
+            }
+            return Some(0);
+        }
+    }
+    None
+}
+
+fn value_as_f64(x: &serde_json::Value) -> Option<f64> {
+    if x.is_null() {
+        return None;
+    }
+    if let Some(n) = x.as_f64() {
+        return Some(if n.is_finite() { n } else { 0.0 });
+    }
+    if let Some(n) = x.as_i64() {
+        return Some(n as f64);
+    }
+    if let Some(n) = x.as_u64() {
+        return Some(n as f64);
+    }
+    if let Some(s) = x.as_str() {
+        let s = s.trim();
+        if s.is_empty() {
+            return None;
+        }
+        if let Ok(n) = s.parse::<f64>() {
+            return Some(if n.is_finite() { n } else { 0.0 });
+        }
+    }
+    None
+}
+
 fn clip_field(value: &str, max: usize) -> String {
     value
         .chars()
@@ -143,8 +371,26 @@ fn clip_field(value: &str, max: usize) -> String {
 }
 
 pub fn valid_iso_date(value: &str) -> bool {
-    value.len() == 10
-        && chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d").is_ok()
+    value.len() == 10 && chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d").is_ok()
+}
+
+fn looks_like_timestamp(value: &str) -> bool {
+    let b = value.as_bytes();
+    b.len() >= 19
+        && b[4] == b'-'
+        && b[7] == b'-'
+        && (b[10] == b'T' || b[10] == b' ')
+        && b[13] == b':'
+        && b[16] == b':'
+}
+
+fn sanitize_ts(value: Option<String>) -> Option<String> {
+    let s = clip_field(value?.trim(), 32);
+    if looks_like_timestamp(&s) {
+        Some(s)
+    } else {
+        None
+    }
 }
 
 /// Drop forged tenant fields and junk rows before the worker stamps identity.
@@ -167,6 +413,10 @@ pub fn sanitize_event(mut row: EventRow) -> Option<EventRow> {
     row.block_id = clip_field(&row.block_id, 128);
     row.created_at = clip_field(&row.created_at, 32);
     row.updated_at = clip_field(&row.updated_at, 32);
+    row.start_time = sanitize_ts(row.start_time);
+    row.end_time = sanitize_ts(row.end_time);
+    row.actual_end_time = sanitize_ts(row.actual_end_time);
+    row.usage_limit_reset_time = sanitize_ts(row.usage_limit_reset_time);
     row.account_id.clear();
     row.api_key_id.clear();
     row.dedup_key.clear();
@@ -187,7 +437,12 @@ pub fn stamp_ingest_identity(row: &mut EventRow, account_id: &str, api_key_id: &
     row.api_key_id = api_key_id.to_string();
     row.dedup_key = sha256_hex16(&format!(
         "{}|{}|{}|{}|{}|{}|{}",
-        row.account_id, row.source, row.machine_name, row.record_type, row.date, row.model_name,
+        row.account_id,
+        row.source,
+        row.machine_name,
+        row.record_type,
+        row.date,
+        row.model_name,
         row.record_key
     ));
     if row.created_at.is_empty() {
@@ -362,6 +617,18 @@ mod tests {
     }
 
     #[test]
+    fn sanitize_drops_invalid_timestamps() {
+        let mut row = EventRow::default();
+        row.date = "2026-08-19".into();
+        row.record_type = "session".into();
+        row.start_time = Some("later".into());
+        row.end_time = Some("2026-08-19 12:00:00".into());
+        let out = sanitize_event(row).unwrap();
+        assert!(out.start_time.is_none());
+        assert_eq!(out.end_time.as_deref(), Some("2026-08-19 12:00:00"));
+    }
+
+    #[test]
     fn stamp_overwrites_client_dedup_with_account() {
         let mut row = EventRow {
             date: "2026-08-19".into(),
@@ -388,5 +655,188 @@ mod tests {
         assert!(!ingest_body_too_large(None));
         assert!(!ingest_body_too_large(Some("100")));
         assert!(ingest_body_too_large(Some("2000000")));
+    }
+
+    fn sample_ingest_json() -> serde_json::Value {
+        serde_json::json!({
+            "events": [{
+                "date": "2026-08-19",
+                "record_type": "session",
+                "record_key": "s1",
+                "source": "cursor",
+                "machine_name": "account",
+                "model_name": "grok-4.5",
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+                "cost": 1.25,
+                "entries": 1
+            }]
+        })
+    }
+
+    #[test]
+    fn parse_ingest_success_keeps_payload_totals() {
+        let parsed = parse_ingest_bytes(sample_ingest_json().to_string().as_bytes()).unwrap();
+        assert_eq!(parsed.rejected, 0);
+        assert_eq!(parsed.events.len(), 1);
+        let row = &parsed.events[0];
+        assert_eq!(row.source, "cursor");
+        assert_eq!(row.total_tokens, 120);
+        assert!((row.cost - 1.25).abs() < 1e-12);
+        assert!(row.account_id.is_empty());
+        assert!(row.dedup_key.is_empty());
+    }
+
+    #[test]
+    fn parse_ingest_auth_payload_shape_is_object_with_events() {
+        assert_eq!(
+            parse_ingest_bytes(b"not json").unwrap_err(),
+            IngestParseError::InvalidJson
+        );
+        assert_eq!(
+            parse_ingest_bytes(b"[]").unwrap_err(),
+            IngestParseError::InvalidJson
+        );
+        assert_eq!(
+            parse_ingest_bytes(br#"{"events":null}"#).unwrap_err(),
+            IngestParseError::EventsNotArray
+        );
+        assert_eq!(
+            parse_ingest_bytes(br#"{"events":{}}"#).unwrap_err(),
+            IngestParseError::EventsNotArray
+        );
+        let empty = parse_ingest_bytes(br#"{"events":[]}"#).unwrap();
+        assert!(empty.events.is_empty());
+        assert_eq!(empty.rejected, 0);
+    }
+
+    #[test]
+    fn parse_ingest_malformed_event_does_not_drop_siblings() {
+        let body = serde_json::json!({
+            "events": [
+                {"date": "2026-08-19", "record_type": "daily", "source": "grok", "total_tokens": 9, "cost": 0.5},
+                "nope",
+                {"date": "bad", "record_type": "daily"},
+                {"date": "2026-08-20", "record_type": "session", "source": "cursor", "input_tokens": 10.9, "totalTokens": "11", "cost": "0.25"}
+            ]
+        });
+        let parsed = parse_ingest_bytes(body.to_string().as_bytes()).unwrap();
+        assert_eq!(parsed.events.len(), 2);
+        assert_eq!(parsed.rejected, 2);
+        assert_eq!(parsed.events[0].source, "grok");
+        assert_eq!(parsed.events[0].total_tokens, 9);
+        assert_eq!(parsed.events[1].input_tokens, 10);
+        assert_eq!(parsed.events[1].total_tokens, 11);
+        assert!((parsed.events[1].cost - 0.25).abs() < 1e-12);
+    }
+
+    #[test]
+    fn parse_ingest_camel_case_keeps_ccusage_tokens() {
+        let body = serde_json::json!({
+            "events": [{
+                "date": "2026-08-19",
+                "recordType": "daily",
+                "recordKey": "2026-08-19",
+                "source": "ccusage",
+                "machineName": "host",
+                "modelName": "claude-sonnet",
+                "inputTokens": 250777,
+                "outputTokens": 10,
+                "cacheCreationTokens": 3,
+                "cacheReadTokens": 4,
+                "totalTokens": 250794,
+                "totalCost": 1.5
+            }]
+        });
+        let parsed = parse_ingest_bytes(body.to_string().as_bytes()).unwrap();
+        assert_eq!(parsed.events.len(), 1);
+        let row = &parsed.events[0];
+        assert_eq!(row.record_type, "daily");
+        assert_eq!(row.input_tokens, 250777);
+        assert_eq!(row.cache_creation_tokens, 3);
+        assert_eq!(row.cache_read_tokens, 4);
+        assert_eq!(row.total_tokens, 250794);
+        assert!((row.cost - 1.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn parse_ingest_does_not_invent_cost() {
+        let body = serde_json::json!({
+            "events": [{
+                "date": "2026-08-19",
+                "record_type": "session",
+                "source": "grok",
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120
+            }]
+        });
+        let parsed = parse_ingest_bytes(body.to_string().as_bytes()).unwrap();
+        assert_eq!(parsed.events[0].cost, 0.0);
+        assert_eq!(parsed.events[0].total_tokens, 120);
+    }
+
+    #[test]
+    fn parse_ingest_too_many_events_is_413() {
+        let events: Vec<_> = (0..MAX_INGEST_EVENTS + 1)
+            .map(|i| serde_json::json!({"date": "2026-08-19", "record_type": "daily", "record_key": i.to_string()}))
+            .collect();
+        let body = serde_json::json!({ "events": events });
+        let err = parse_ingest_bytes(body.to_string().as_bytes()).unwrap_err();
+        assert_eq!(err, IngestParseError::TooManyEvents);
+        assert_eq!(err.status(), 413);
+    }
+
+    #[test]
+    fn parse_ingest_null_strings_do_not_fail_the_body() {
+        let body = serde_json::json!({
+            "events": [{
+                "date": "2026-08-19",
+                "record_type": "session",
+                "source": "cursor-cloud-agent",
+                "model_name": null,
+                "session_id": null,
+                "start_time": "not-a-timestamp",
+                "end_time": "2026-08-19 01:02:03",
+                "is_active": true,
+                "entries": 2.0,
+                "cost": 0
+            }]
+        });
+        let parsed = parse_ingest_bytes(body.to_string().as_bytes()).unwrap();
+        assert_eq!(parsed.events.len(), 1);
+        let row = &parsed.events[0];
+        assert!(row.model_name.is_empty());
+        assert!(row.start_time.is_none());
+        assert_eq!(row.end_time.as_deref(), Some("2026-08-19 01:02:03"));
+        assert_eq!(row.is_active, 1);
+        assert_eq!(row.entries, 2);
+        assert_eq!(row.cost, 0.0);
+    }
+
+    #[test]
+    fn ingest_parse_error_status_is_never_500() {
+        for err in [
+            IngestParseError::InvalidJson,
+            IngestParseError::EventsNotArray,
+            IngestParseError::TooLarge,
+            IngestParseError::TooManyEvents,
+        ] {
+            assert!(err.status() < 500, "{err:?} must be 4xx");
+        }
+    }
+
+    #[test]
+    fn ingest_body_strict_serde_is_not_the_http_path() {
+        let row = r#"{"date":"2026-08-19","record_type":"daily","input_tokens":1.5,"cost":"0.25"}"#;
+        assert!(
+            serde_json::from_str::<EventRow>(row).is_err(),
+            "strict EventRow serde must not be used for /v1/ingest"
+        );
+        let parsed = parse_ingest_bytes(format!(r#"{{"events":[{row}]}}"#).as_bytes()).unwrap();
+        assert_eq!(parsed.events.len(), 1);
+        assert_eq!(parsed.events[0].input_tokens, 1);
+        assert!((parsed.events[0].cost - 0.25).abs() < 1e-12);
     }
 }

--- a/apps/api/src/types.rs
+++ b/apps/api/src/types.rs
@@ -162,9 +162,8 @@ pub struct ParsedIngest {
 
 /// Parse `/v1/ingest` from raw bytes with `serde_json`.
 ///
-/// Worker `Request::json` uses `serde_wasm_bindgen` (JS numbers are f64), which
-/// rejects `u64` token fields and `null` strings as a hard error for the whole
-/// body. One bad row must not 500 or drop a 400-event chunk.
+/// Avoid Worker `Request::json` (`serde_wasm_bindgen`): a type mismatch or
+/// `null` string fails the whole body. Skip bad rows; keep sibling totals.
 pub fn parse_ingest_bytes(bytes: &[u8]) -> std::result::Result<ParsedIngest, IngestParseError> {
     if bytes.len() as u64 > MAX_INGEST_BYTES {
         return Err(IngestParseError::TooLarge);
@@ -709,6 +708,9 @@ mod tests {
         let empty = parse_ingest_bytes(br#"{"events":[]}"#).unwrap();
         assert!(empty.events.is_empty());
         assert_eq!(empty.rejected, 0);
+        let bare = parse_ingest_bytes(br#"{}"#).unwrap();
+        assert!(bare.events.is_empty());
+        assert_eq!(bare.rejected, 0);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`POST /v1/ingest` on the Cloudflare Worker used `Request::json()`, which in workers-rs 0.8 is `JSON.parse` + `serde_wasm_bindgen`. JS numbers are f64, so `u64` token fields, `null` strings, and a single bad row could fail the whole body. That shows up as Cloudflare 1101 / 500, or as a dropped 400-row CLI chunk (session totals go missing). Auth failures were classified by matching `"unauthorized"` in `worker::Error` text, so D1/bind errors became 500s that echoed internals.

No open ingest ticket; this continues the #95 ingest hardening (tenant stamp, payload caps) without touching Dependency Dashboard #6 or the Rust migration epic.

## What

- Parse ingest from raw bytes with `serde_json` (never `Request::json` / wasm-bindgen).
- Client mistakes are 4xx: invalid JSON / non-array `events` → 400, oversize → 413. Auth: missing/wrong token → 401; D1 unavailable → 503 (`auth unavailable`), no leaked error strings.
- One invalid event is skipped (`rejected`) instead of failing the batch. Valid siblings keep their payload tokens and cost.
- Accept camelCase (`inputTokens`, `totalCost`, …) and string/float numbers from real CLI/session payloads. Missing cost stays `0` — nothing is invented.
- Drop junk timestamps so ClickHouse JSONEachRow does not 502 on `"later"` / empty strings.

## Tests

```bash
cargo test --locked -p summa-api --lib
cargo check --locked -p summa-api --target wasm32-unknown-unknown
```

43 Worker unit tests (ingest success, auth prefix, malformed/null/camelCase payloads, no invented cost, 4xx never 500). Wasm check clean.

Could not hit live `https://summa.duyet.net/v1/ingest` from this environment (no telemetry token in the PR; secrets stay out).

## Review

Start at `apps/api/src/lib.rs` `ingest()`, then `parse_ingest_bytes` / `event_from_json` in `types.rs`, then typed `AuthError` in `auth.rs`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7553625-ad77-4a5b-9178-6d13b78db286?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7553625-ad77-4a5b-9178-6d13b78db286&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Harden the `/v1/ingest` API so malformed client data and authentication failures receive safe, appropriate responses without dropping valid usage totals.

Bug Fixes:
- Return clear 4xx responses for malformed or oversized ingest payloads and distinguish unauthorized requests from unavailable authentication services.
- Preserve valid ingest events and their token and cost totals when individual rows contain malformed, null, or loosely typed fields.
- Prevent invalid timestamps from reaching downstream ClickHouse ingestion.

Enhancements:
- Support common camelCase and string or floating-point representations in ingest payloads while reporting rejected rows.

Tests:
- Add coverage for ingest parsing, payload compatibility, rejected-row handling, authentication statuses, timestamp sanitization, and non-500 client errors.