### PR TITLE
fix(install): reject sha256 sidecars with extra records

### DIFF
--- a/apps/cli/src/script/update.rs
+++ b/apps/cli/src/script/update.rs
@@ -125,12 +125,15 @@ pub fn sha256_sidecar_url(tarball_url: &str) -> String {
 }
 
 /// First field of a GNU `shasum -a 256` sidecar (`<hex>  dist/<asset>.tar.gz`).
+/// Exactly one non-empty record; extra lines (malformed or conflicting) fail closed.
 pub fn parse_sha256_sidecar(text: &str) -> anyhow::Result<String> {
-    let line = text
-        .lines()
-        .map(|l| l.trim().trim_end_matches('\r'))
-        .find(|l| !l.is_empty())
+    let mut records = text.lines().map(str::trim).filter(|l| !l.is_empty());
+    let line = records
+        .next()
         .ok_or_else(|| anyhow!("checksum file is empty"))?;
+    if records.next().is_some() {
+        bail!("malformed checksum file: expected exactly one checksum record");
+    }
     let hex = line
         .split_whitespace()
         .next()
@@ -964,6 +967,12 @@ mod tests {
         assert!(parse_sha256_sidecar("").is_err());
         assert!(parse_sha256_sidecar("not-a-hash  file.tar.gz\n").is_err());
         assert!(parse_sha256_sidecar("abc  file\n").is_err());
+        let extra = format!("{text}deadbeef  other.tar.gz\n");
+        assert!(parse_sha256_sidecar(&extra).is_err());
+        assert_eq!(
+            parse_sha256_sidecar(&format!("{text}\n\n")).unwrap(),
+            "3f97eacb7335bd7e91de18f5703050da387d88e12733b8c4f893105adc34489c"
+        );
     }
 
     #[test]

--- a/install.sh
+++ b/install.sh
@@ -45,8 +45,13 @@ need_sha256() {
 }
 
 # First field of a GNU `shasum -a 256` sidecar (`<hex>  dist/<asset>.tar.gz`).
+# Exactly one non-empty record; extra lines fail closed.
 parse_sha256_sidecar() {
-  local sidecar="$1" hex
+  local sidecar="$1" hex n
+  n="$(tr -d '\r' < "$sidecar" | awk 'NF { n++ } END { print n+0 }')"
+  if [ "$n" -ne 1 ]; then
+    die "malformed checksum file ${sidecar}: expected exactly one checksum record, got ${n}"
+  fi
   hex="$(tr -d '\r' < "$sidecar" | awk 'NF { print $1; exit }')"
   hex="$(printf '%s' "$hex" | tr '[:upper:]' '[:lower:]')"
   if [ "${#hex}" -ne 64 ]; then

--- a/scripts/ci/validate-deploy.sh
+++ b/scripts/ci/validate-deploy.sh
@@ -69,11 +69,16 @@ tar -C "$www/beta" -czf "$www/beta/${asset}.tar.gz" "$asset"
     sha256sum "${asset}.tar.gz" > "${asset}.tar.gz.sha256"
   fi
 )
-mkdir -p "$www/mismatch/beta" "$www/nochecksum/beta"
+mkdir -p "$www/mismatch/beta" "$www/nochecksum/beta" "$www/extra/beta"
 cp "$www/beta/${asset}.tar.gz" "$www/mismatch/beta/"
 cp "$www/beta/${asset}.tar.gz" "$www/nochecksum/beta/"
+cp "$www/beta/${asset}.tar.gz" "$www/extra/beta/"
 printf '%s  %s\n' "0000000000000000000000000000000000000000000000000000000000000000" "${asset}.tar.gz" \
   > "$www/mismatch/beta/${asset}.tar.gz.sha256"
+{
+  cat "$www/beta/${asset}.tar.gz.sha256"
+  printf '%s  %s\n' "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "other.tar.gz"
+} > "$www/extra/beta/${asset}.tar.gz.sha256"
 cp install.sh "$www/install.sh"
 portfile="$tmp/http.port"
 python3 - "$www" "$portfile" <<'PY' &
@@ -150,6 +155,21 @@ printf '%s\n' "$nocheck_out"
 grep -q 'checksum not found' <<<"$nocheck_out" || fail "missing-sidecar error missing 'checksum not found'"
 [[ ! -x "$nochecksum_bin/summa" ]] || fail "missing-checksum install left a binary"
 ok "install.sh missing checksum is fatal"
+
+extra_bin="$tmp/extra-bin"
+mkdir -p "$extra_bin" "$tmp/home-extra"
+extra_out=""
+extra_rc=0
+if extra_out="$(run_install extra "$extra_bin" 2>&1)"; then
+  extra_rc=0
+else
+  extra_rc=$?
+fi
+printf '%s\n' "$extra_out"
+[ "$extra_rc" -ne 0 ] || fail "install.sh accepted a sidecar with extra records"
+grep -q 'exactly one checksum record' <<<"$extra_out" || fail "extra-record error missing 'exactly one checksum record'"
+[[ ! -x "$extra_bin/summa" ]] || fail "extra-record install left a binary"
+ok "install.sh extra checksum records are fatal"
 
 kill "$http_pid" >/dev/null 2>&1 || true
 wait "$http_pid" >/dev/null 2>&1 || true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #108 (which squash-merged before this commit landed).

Sourcery noted that `parse_sha256_sidecar` accepted a valid first line and ignored extra content. A sidecar with a good digest plus a conflicting second line would still verify.

This requires **exactly one** non-empty record in the GNU `shasum -a 256` sidecar (trailing blank lines still OK). Extra records abort before extract in `install.sh` and `summa update`.

Covered by a unit test and `scripts/ci/validate-deploy.sh` (`expected exactly one checksum record, got 2`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9ca4301-ce17-4bd5-be4a-f59402fe2a2f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9ca4301-ce17-4bd5-be4a-f59402fe2a2f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Require SHA-256 sidecars to contain exactly one non-empty checksum record before verifying or extracting artifacts.

Bug Fixes:
- Reject SHA-256 sidecars containing multiple non-empty checksum records instead of accepting only the first record.
- Prevent installations and updates from proceeding when checksum sidecars contain conflicting or malformed extra records.

CI:
- Extend deployment validation to verify that extra checksum records fail safely without leaving an installed binary.

Tests:
- Add parser coverage for rejecting extra records while permitting trailing blank lines.