### PR TITLE
fix(ci): isolate env-mutating tests so cargo test can run in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
       run: cargo check --locked -p summa-import
 
     - name: cargo test -p summa-import
-      # Env-mutating config/credentials tests race under the default thread pool.
-      run: cargo test --locked -p summa-import -- --test-threads=1
+      # Env-mutating tests hold crate::test_env::EnvLock; the rest uses the default thread pool.
+      run: cargo test --locked -p summa-import
 
     - name: cargo package -p summa-import
       run: cargo package --locked -p summa-import --list | tee /tmp/summa-package.list

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Docs index: `docs/INDEX.md` (core memory: `docs/knowledge/core-memory.md`).
 bun run check                           # CLI cargo check + API wasm check
 bun run build:cli                       # cargo build --locked --bin summa (not --release)
 bun run build:api                       # Worker typecheck
-bun run test                            # CLI + API cargo test --test-threads=1
+bun run test                            # CLI + API cargo test (CLI env tests hold EnvLock)
 bun run test:deploy                     # install.sh / k8s / wrangler / release-please
 bun run deploy:api                      # wrangler deploy (apps/api)
 cargo test --locked -p summa-import     # CLI tests

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "cargo build --locked --bin summa --manifest-path Cargo.toml",
     "check": "cargo check --locked --manifest-path Cargo.toml",
-    "test": "cargo test --locked --manifest-path Cargo.toml -- --test-threads=1",
+    "test": "cargo test --locked --manifest-path Cargo.toml",
     "dev": "cargo run --manifest-path Cargo.toml -- import --verbose"
   }
 }

--- a/apps/cli/src/config.rs
+++ b/apps/cli/src/config.rs
@@ -561,9 +561,13 @@ impl Config {
     }
 
     pub fn interpolate_env(input: &str) -> String {
+        Self::interpolate_env_with(input, |k| std::env::var(k).ok())
+    }
+
+    fn interpolate_env_with(input: &str, env_lookup: impl Fn(&str) -> Option<String>) -> String {
         let re = regex::Regex::new(r"\$\{([^}]+)\}").expect("valid env interpolation regex");
         re.replace_all(input, |caps: &regex::Captures<'_>| {
-            std::env::var(&caps[1]).unwrap_or_else(|_| caps[0].to_string())
+            env_lookup(&caps[1]).unwrap_or_else(|| caps[0].to_string())
         })
         .to_string()
     }
@@ -818,38 +822,8 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
+    use crate::test_env::EnvLock;
     use std::io::Write;
-
-    struct EnvGuard {
-        keys: &'static [&'static str],
-        prev: Vec<Option<String>>,
-    }
-
-    impl EnvGuard {
-        fn new(keys: &'static [&'static str]) -> Self {
-            let prev = keys.iter().map(|k| env::var(k).ok()).collect();
-            for key in keys {
-                let _ = env::remove_var(key);
-            }
-            Self { keys, prev }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (key, prev_val) in self.keys.iter().zip(self.prev.drain(..)) {
-                match prev_val {
-                    Some(v) => {
-                        let _ = env::set_var(key, v);
-                    }
-                    None => {
-                        let _ = env::remove_var(key);
-                    }
-                }
-            }
-        }
-    }
 
     #[test]
     fn empty_toml_returns_defaults() {
@@ -887,9 +861,9 @@ mod tests {
 
     #[test]
     fn env_interpolation_replaces_placeholders() {
-        let _guard = EnvGuard::new(&["MY_CH_HOST", "MY_CH_DB"]);
-        env::set_var("MY_CH_HOST", "db.example.com");
-        env::set_var("MY_CH_DB", "prod");
+        let mut env_map: HashMap<String, String> = HashMap::new();
+        env_map.insert("MY_CH_HOST".into(), "db.example.com".into());
+        env_map.insert("MY_CH_DB".into(), "prod".into());
         let toml_str = r#"
             [clickhouse]
             host = "${MY_CH_HOST}"
@@ -899,14 +873,14 @@ mod tests {
             database = "${MY_CH_DB}"
             protocol = "http"
         "#;
-        let cfg: Config = toml::from_str(&Config::interpolate_env(toml_str)).unwrap();
+        let interpolated = Config::interpolate_env_with(toml_str, |k| env_map.get(k).cloned());
+        let cfg: Config = toml::from_str(&interpolated).unwrap();
         assert_eq!(cfg.clickhouse.host, "db.example.com");
         assert_eq!(cfg.clickhouse.database, "prod");
     }
 
     #[test]
     fn env_interpolation_keeps_placeholder_on_missing() {
-        let _guard = EnvGuard::new(&["MISSING_VAR"]);
         let toml_str = r#"
             [clickhouse]
             host = "${MISSING_VAR}"
@@ -916,21 +890,13 @@ mod tests {
             database = "analytics"
             protocol = "http"
         "#;
-        let cfg: Config = toml::from_str(&Config::interpolate_env(toml_str)).unwrap();
+        let interpolated = Config::interpolate_env_with(toml_str, |_| None);
+        let cfg: Config = toml::from_str(&interpolated).unwrap();
         assert_eq!(cfg.clickhouse.host, "${MISSING_VAR}");
     }
 
     #[test]
     fn apply_env_fallback_when_fields_empty() {
-        const KEYS: &[&str] = &[
-            "CH_HOST",
-            "CH_PORT",
-            "CH_DATABASE",
-            "DUCKDB_PATH",
-            "IMPORT_MACHINE_NAME",
-        ];
-        let _guard = EnvGuard::new(KEYS);
-
         let mut env_map: HashMap<String, String> = HashMap::new();
         env_map.insert("CH_HOST".into(), "env-host".into());
         env_map.insert("CH_PORT".into(), "8443".into());
@@ -1003,6 +969,7 @@ mod tests {
 
     #[test]
     fn credentials_fill_password_separately_from_main_config() {
+        let _env = EnvLock::isolate_summa();
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("config.toml");
         let creds_path = dir.path().join("credentials.toml");
@@ -1045,7 +1012,6 @@ motherduck_token = "md-token-xyz"
             std::env::var("MOTHERDUCK_TOKEN").ok().as_deref(),
             Some("md-token-xyz")
         );
-        let _ = env::remove_var("MOTHERDUCK_TOKEN");
     }
 
     #[test]
@@ -1060,11 +1026,13 @@ motherduck_token = "md-token-xyz"
 
     #[test]
     fn resolve_duckdb_path_prefers_explicit_over_default() {
+        let _env = EnvLock::isolate_summa();
         let p = Config::resolve_duckdb_path(Some("md:cloud-db"));
         assert_eq!(p, "md:cloud-db");
         let local = Config::resolve_duckdb_path(Some(""));
-        // empty explicit falls through to env or default
+        // empty explicit falls through to default (DUCKDB_PATH isolated)
         assert!(!local.is_empty());
+        assert!(!local.starts_with("md:"));
     }
 
     #[test]
@@ -1131,11 +1099,11 @@ motherduck_token = "md-token-xyz"
 
     #[test]
     fn update_channel_env_fallback() {
-        let _guard = EnvGuard::new(&["SUMMA_UPDATE_CHANNEL", "SUMMA_UPDATE_MODE"]);
+        let env = EnvLock::isolate_summa();
         let cfg = Config::default();
-        std::env::set_var("SUMMA_UPDATE_CHANNEL", "stable");
+        env.set("SUMMA_UPDATE_CHANNEL", "stable");
         assert_eq!(cfg.update_channel(), UpdateChannel::Stable);
-        std::env::set_var("SUMMA_UPDATE_MODE", "auto");
+        env.set("SUMMA_UPDATE_MODE", "auto");
         assert_eq!(cfg.update_mode(), UpdateMode::Auto);
     }
 
@@ -1180,32 +1148,21 @@ motherduck_token = "md-token-xyz"
 
     #[test]
     fn load_missing_file_returns_defaults() {
-        let _guard = EnvGuard::new(&[
-            "CH_HOST",
-            "CH_PORT",
-            "CH_USER",
-            "CH_PASSWORD",
-            "CH_DATABASE",
-            "CH_PROTOCOL",
-            "DUCKDB_PATH",
-            "IMPORT_MACHINE_NAME",
-            CONFIG_ENV,
-            LEGACY_CONFIG_ENV,
-            CREDENTIALS_ENV,
-        ]);
+        let env = EnvLock::isolate_summa();
         // Isolated empty file — `load(None)` would pick up a live XDG config.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("empty.toml");
         std::fs::write(&path, "").unwrap();
         let creds = dir.path().join("credentials.toml");
         std::fs::write(&creds, "").unwrap();
-        std::env::set_var(CREDENTIALS_ENV, creds.to_str().unwrap());
+        env.set(CREDENTIALS_ENV, creds.to_str().unwrap());
         let cfg = Config::load(Some(path.to_str().unwrap())).unwrap();
         assert!(cfg.clickhouse.host.is_empty());
     }
 
     #[test]
     fn credentials_candidate_paths_include_xdg() {
+        let _env = EnvLock::isolate_summa();
         let paths = Credentials::candidate_paths();
         assert!(paths.iter().any(|p| p.ends_with("credentials.toml")));
     }
@@ -1309,9 +1266,11 @@ impl SinkRoutes {
 #[cfg(test)]
 mod sink_routes_tests {
     use super::*;
+    use crate::test_env::EnvLock;
 
     #[test]
     fn routes_local_when_configured() {
+        let _env = EnvLock::isolate_summa();
         let cfg = Config {
             sinks: SinksConfig {
                 routes: vec!["local".into()],
@@ -1350,6 +1309,7 @@ mod sink_routes_tests {
 
     #[test]
     fn routes_clickhouse_when_host_set() {
+        let _env = EnvLock::isolate_summa();
         let cfg = Config {
             sinks: SinksConfig {
                 routes: vec!["clickhouse".into()],

--- a/apps/cli/src/lib.rs
+++ b/apps/cli/src/lib.rs
@@ -16,6 +16,9 @@ pub mod source;
 pub mod telemetry;
 pub mod util;
 
+#[cfg(test)]
+pub(crate) mod test_env;
+
 pub use model::{
     DataSink, DataSource, EventRow, EventsSnapshotData, PipelineResult, SinkResult, SourceResult,
 };

--- a/apps/cli/src/script/import_all.rs
+++ b/apps/cli/src/script/import_all.rs
@@ -258,6 +258,7 @@ pub async fn run(args: ImportArgs, verbose: bool) -> anyhow::Result<()> {
             since: effective_since.clone(),
             end_date: end_date.clone(),
             import_id: import_id.clone(),
+            base_dir: None,
         })));
     }
 
@@ -511,6 +512,7 @@ mod tests {
 
     #[test]
     fn default_duckdb_is_local_not_motherduck() {
+        let _env = crate::test_env::EnvLock::isolate_summa();
         let path = crate::config::Config::resolve_duckdb_path(None);
         assert!(
             !path.starts_with("md:"),
@@ -526,26 +528,7 @@ mod tests {
     fn prepare_import_applies_config_and_credentials_files() {
         use std::io::Write;
 
-        // Isolate from ambient env secrets/paths.
-        const KEYS: &[&str] = &[
-            "CH_HOST",
-            "CH_PORT",
-            "CH_USER",
-            "CH_PASSWORD",
-            "CH_DATABASE",
-            "CH_PROTOCOL",
-            "DUCKDB_PATH",
-            "MOTHERDUCK_TOKEN",
-            "IMPORT_DAYS_BACK",
-            "IMPORT_MACHINE_NAME",
-            "SUMMA_CONFIG",
-            "SUMMA_CREDENTIALS",
-            "CCUSAGE_IMPORT_CONFIG",
-        ];
-        let prev: Vec<Option<String>> = KEYS.iter().map(|k| env::var(k).ok()).collect();
-        for k in KEYS {
-            let _ = env::remove_var(k);
-        }
+        let _env = crate::test_env::EnvLock::isolate_summa();
 
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("summa.toml");
@@ -651,32 +634,13 @@ motherduck_token = "md-from-credentials"
             env::var("MOTHERDUCK_TOKEN").ok().as_deref(),
             Some("md-from-credentials")
         );
-
-        // Restore ambient env.
-        for (key, prev_val) in KEYS.iter().zip(prev) {
-            match prev_val {
-                Some(v) => env::set_var(key, v),
-                None => env::remove_var(key),
-            }
-        }
     }
 
     #[test]
     fn prepare_import_cli_overrides_config_duckdb_and_days() {
         use std::io::Write;
 
-        const KEYS: &[&str] = &[
-            "CH_HOST",
-            "CH_PASSWORD",
-            "DUCKDB_PATH",
-            "SUMMA_CONFIG",
-            "SUMMA_CREDENTIALS",
-            "CCUSAGE_IMPORT_CONFIG",
-        ];
-        let prev: Vec<Option<String>> = KEYS.iter().map(|k| env::var(k).ok()).collect();
-        for k in KEYS {
-            let _ = env::remove_var(k);
-        }
+        let _env = crate::test_env::EnvLock::isolate_summa();
 
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("summa.toml");
@@ -717,13 +681,6 @@ days_back = 30
         assert_eq!(prepared.duckdb_path, "/from/cli.duckdb");
         assert_eq!(prepared.days_back, Some(2));
         assert!(prepared.skip_clickhouse);
-
-        for (key, prev_val) in KEYS.iter().zip(prev) {
-            match prev_val {
-                Some(v) => env::set_var(key, v),
-                None => env::remove_var(key),
-            }
-        }
     }
 
     fn skip_all_import_args() -> ImportArgs {

--- a/apps/cli/src/sink/duckdb.rs
+++ b/apps/cli/src/sink/duckdb.rs
@@ -12,6 +12,14 @@ pub struct DuckDbSink {
     is_motherduck: bool,
 }
 
+fn append_motherduck_token(db_path: &str, token: &str) -> String {
+    if token.is_empty() {
+        return db_path.to_string();
+    }
+    let sep = if db_path.contains('?') { '&' } else { '?' };
+    format!("{db_path}{sep}motherduck_token={token}")
+}
+
 impl DuckDbSink {
     pub fn new(db_path: impl Into<String>) -> Self {
         let db_path = db_path.into();
@@ -33,11 +41,7 @@ impl DuckDbSink {
             return self.db_path.clone();
         }
         let token = std::env::var("MOTHERDUCK_TOKEN").unwrap_or_default();
-        if token.is_empty() {
-            return self.db_path.clone();
-        }
-        let sep = if self.db_path.contains('?') { '&' } else { '?' };
-        format!("{}{}motherduck_token={}", self.db_path, sep, token)
+        append_motherduck_token(&self.db_path, &token)
     }
 
     fn duckdb_create_sql() -> &'static str {
@@ -467,12 +471,15 @@ mod tests {
 
     #[test]
     fn motherduck_connection_string_appends_token() {
-        std::env::set_var("MOTHERDUCK_TOKEN", "test-token-xyz");
-        let sink = DuckDbSink::new("md:ccusage");
-        let cs = sink.connection_string();
-        assert!(cs.starts_with("md:ccusage"));
-        assert!(cs.contains("motherduck_token=test-token-xyz"));
-        std::env::remove_var("MOTHERDUCK_TOKEN");
+        assert_eq!(
+            append_motherduck_token("md:ccusage", "test-token-xyz"),
+            "md:ccusage?motherduck_token=test-token-xyz"
+        );
+        assert_eq!(
+            append_motherduck_token("md:ccusage?x=1", "tok"),
+            "md:ccusage?x=1&motherduck_token=tok"
+        );
+        assert_eq!(append_motherduck_token("md:ccusage", ""), "md:ccusage");
     }
 
     #[test]

--- a/apps/cli/src/source/hermes.rs
+++ b/apps/cli/src/source/hermes.rs
@@ -30,6 +30,8 @@ pub struct HermesSourceOptions {
     pub since: Option<String>,
     pub end_date: Option<String>,
     pub import_id: String,
+    /// Override Hermes home (tests). When None, uses `HERMES_HOME` or `~/.hermes`.
+    pub base_dir: Option<PathBuf>,
 }
 
 // ---------------------------------------------------------------------------
@@ -65,6 +67,7 @@ impl DataSource for HermesSource {
             since,
             end_date,
             import_id,
+            base_dir,
         } = &self.opts;
 
         let effective_since = if let Some(s) = since {
@@ -80,10 +83,15 @@ impl DataSource for HermesSource {
             None
         };
 
-        let home_dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
-        let base_dir = env::var("HERMES_HOME")
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| home_dir.join(".hermes"));
+        let base_dir = if let Some(d) = base_dir {
+            d.clone()
+        } else if let Ok(h) = env::var("HERMES_HOME") {
+            PathBuf::from(h)
+        } else {
+            dirs::home_dir()
+                .unwrap_or_else(|| PathBuf::from("/tmp"))
+                .join(".hermes")
+        };
         let db_path = base_dir.join("state.db");
 
         let mut events: Vec<EventRow> = Vec::new();
@@ -392,6 +400,7 @@ mod tests {
             since: None,
             end_date: None,
             import_id: "".into(),
+            base_dir: None,
         });
         assert_eq!(src.name(), "hermes");
     }
@@ -419,8 +428,6 @@ mod tests {
         .unwrap();
         drop(conn);
 
-        let prev_home = env::var("HERMES_HOME").ok();
-        env::set_var("HERMES_HOME", tmp.path());
         let src = HermesSource::new(HermesSourceOptions {
             machine_name: "duet-ubuntu-hermes".into(),
             hash_projects: false,
@@ -429,12 +436,9 @@ mod tests {
             since: None,
             end_date: None,
             import_id: "test-import".into(),
+            base_dir: Some(tmp.path().to_path_buf()),
         });
         let result = futures::executor::block_on(async move { src.fetch().await }).unwrap();
-        match prev_home {
-            Some(v) => env::set_var("HERMES_HOME", v),
-            None => env::remove_var("HERMES_HOME"),
-        }
 
         assert!(result.error.is_none(), "{:?}", result.error);
         let sessions: Vec<_> = result
@@ -456,9 +460,7 @@ mod tests {
 
     #[test]
     fn test_fetch_returns_ok_when_missing_db() {
-        let orig_home = env::var("HOME").ok();
-        env::set_var("HOME", "/nonexistent/hermes-test-home");
-
+        let tmp = tempfile::tempdir().unwrap();
         let src = HermesSource::new(HermesSourceOptions {
             machine_name: "m1".into(),
             hash_projects: false,
@@ -467,14 +469,9 @@ mod tests {
             since: None,
             end_date: None,
             import_id: "".into(),
+            base_dir: Some(tmp.path().join("missing-hermes")),
         });
         let result = futures::executor::block_on(async move { src.fetch().await });
-
-        if let Some(h) = orig_home {
-            env::set_var("HOME", h);
-        } else {
-            env::remove_var("HOME");
-        }
 
         assert!(result.is_ok());
         let r = result.unwrap();

--- a/apps/cli/src/test_env.rs
+++ b/apps/cli/src/test_env.rs
@@ -1,0 +1,107 @@
+//! Process-wide environment isolation for unit tests.
+//!
+//! `std::env::{set_var, remove_var}` is shared by every test thread. Hold
+//! [`EnvLock`] for the full mutate+assert window so env-dependent tests cannot
+//! race each other or tests that *read* contested keys (`DUCKDB_PATH`,
+//! `MOTHERDUCK_TOKEN`, `CH_*`, …).
+
+use std::ffi::OsStr;
+use std::sync::{Mutex, MutexGuard};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Keys that import/config tests mutate or whose ambient values would change
+/// assertions if a parallel env-mutating test leaked them.
+pub const SUMMA_ENV_KEYS: &[&str] = &[
+    "CH_HOST",
+    "CH_PORT",
+    "CH_USER",
+    "CH_PASSWORD",
+    "CH_DATABASE",
+    "CH_PROTOCOL",
+    "DUCKDB_PATH",
+    "MOTHERDUCK_TOKEN",
+    "motherduck_token",
+    "IMPORT_DAYS_BACK",
+    "IMPORT_MACHINE_NAME",
+    "IMPORT_SINCE",
+    "IMPORT_SINCE_DATE",
+    "IMPORT_END_DATE",
+    "IMPORT_COMMAND_TIMEOUT_MS",
+    "IMPORT_MAX_PARALLEL_WORKERS",
+    "IMPORT_HASH_PROJECT_NAMES",
+    "HASH_PROJECT_NAMES",
+    "SUMMA_CONFIG",
+    "SUMMA_CREDENTIALS",
+    "CCUSAGE_IMPORT_CONFIG",
+    "SUMMA_UPDATE_CHANNEL",
+    "SUMMA_UPDATE_MODE",
+    "SUMMA_TELEMETRY_ENDPOINT",
+    "SUMMA_TELEMETRY_BIND",
+    "SUMMA_TELEMETRY_TOKEN",
+    "CURSOR_SESSION",
+    "CURSOR_COOKIE",
+    "CURSOR_API_KEY",
+    "CODEX_HOME",
+    "OPENCODE_DATA_DIR",
+    "HERMES_HOME",
+    "GROK_HOME",
+];
+
+/// Exclusive access to process env. Restores snapshotted keys on drop.
+pub struct EnvLock {
+    _guard: MutexGuard<'static, ()>,
+    saved: Vec<(String, Option<String>)>,
+}
+
+impl EnvLock {
+    /// Lock the process env, snapshot `keys`, and clear them.
+    pub fn isolate(keys: &[&str]) -> Self {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let saved = keys
+            .iter()
+            .map(|k| ((*k).to_string(), std::env::var(k).ok()))
+            .collect::<Vec<_>>();
+        for key in keys {
+            std::env::remove_var(key);
+        }
+        Self { _guard, saved }
+    }
+
+    /// Isolate the contested summa import/config keys.
+    pub fn isolate_summa() -> Self {
+        Self::isolate(SUMMA_ENV_KEYS)
+    }
+
+    pub fn set(&self, key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) {
+        std::env::set_var(key, value);
+    }
+}
+
+impl Drop for EnvLock {
+    fn drop(&mut self) {
+        for (key, prev) in self.saved.drain(..) {
+            match prev {
+                Some(v) => std::env::set_var(&key, v),
+                None => std::env::remove_var(&key),
+            }
+        }
+    }
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn isolate_clears_sets_and_restores_absent() {
+        let env = EnvLock::isolate(&["SUMMA_TEST_ENV_LOCK_ABSENT"]);
+        assert!(std::env::var("SUMMA_TEST_ENV_LOCK_ABSENT").is_err());
+        env.set("SUMMA_TEST_ENV_LOCK_ABSENT", "inside");
+        assert_eq!(
+            std::env::var("SUMMA_TEST_ENV_LOCK_ABSENT").as_deref(),
+            Ok("inside")
+        );
+        drop(env);
+        assert!(std::env::var("SUMMA_TEST_ENV_LOCK_ABSENT").is_err());
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #103.

`--test-threads=1` was a workaround for process-wide `std::env::{set_var, remove_var}` races, not a real isolation fix. Local `cargo test` (default thread pool) could flake while CI looked green.

## What changed

- Added `crate::test_env::EnvLock`: process-wide mutex that snapshots/clears contested keys (`DUCKDB_PATH`, `MOTHERDUCK_TOKEN`, `CH_*`, …) and restores them on drop.
- Tests that still *must* mutate process env (credentials export, `prepare_import`, update-channel fallback, DuckDB path defaults, sink routes) hold `EnvLock::isolate_summa()` for the whole mutate+assert window.
- Tests that only needed env for fixtures no longer touch process env:
  - config interpolation uses injected `interpolate_env_with`
  - Hermes fetch takes `base_dir` (same pattern as Grok)
  - MotherDuck DSN assembly is a pure `append_motherduck_token` helper
- CI / `bun run test` drop `--test-threads=1`. Safe concurrency is the default cargo test thread pool; env tests serialize on the lock.

## Verification

```text
cargo test --locked -p summa-import -- --test-threads=16
# 257 passed, twice (0.21s / 0.20s)
```

No secrets in the diff. Single-purpose for #103.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-661ff5ad-e957-42d4-b1df-ff0aa9502815?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-661ff5ad-e957-42d4-b1df-ff0aa9502815&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Enable parallel CLI test execution by isolating shared environment mutations and removing unnecessary process-environment dependencies.

Bug Fixes:
- Eliminate flaky environment-variable races in CLI tests so the default Cargo test thread pool can run safely in parallel.

Enhancements:
- Centralize process-wide environment isolation and restoration for tests that must mutate shared environment variables.
- Refactor environment-dependent tests to use injected fixtures or pure helpers where process environment access is unnecessary.
- Allow Hermes tests to use an explicit base directory and simplify MotherDuck connection string testing.

CI:
- Remove single-threaded test execution from CI and the CLI test script.

Documentation:
- Update contributor test instructions to reflect parallel test execution and environment locking.

Tests:
- Add coverage for environment isolation and restoration behavior.