### PR TITLE
Add verify-summa skill (first pstack verification infra)

### DIFF
--- a/.cursor/skills/verify-summa/SKILL.md
+++ b/.cursor/skills/verify-summa/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: verify-summa
+description: >-
+  Verify summa (CLI binary `summa` / crate `summa-import`, plus telemetry API
+  Worker at https://summa.duyet.net): install, update checksum skip, import,
+  check, serve, GET /health, and POST /v1/ingest auth. Use mid-task when proving
+  CLI or hub behavior, after importer/auth/install changes, or before claiming a
+  fix. Isolated PTY/HTTP only; never invent costs or POST fake billed sessions.
+---
+
+# Verify summa
+
+Project-local harness for **summa**. Later agents run this cold. Do not interview the user.
+
+**Primary surface:** CLI `summa` (`apps/cli`, crate `summa-import`). Drive with isolated subprocess / PTY and transcripts.
+
+**Secondary surface:** Telemetry hub `https://summa.duyet.net` (`apps/api`, Cloudflare Worker). Drive with HTTP. Unauthenticated `POST /v1/ingest` must be **401**, never 500. Do not POST fake sessions with invented dollars.
+
+There is no local product HTTP server. `summa serve` pings the cloud hub and exits. Do not start `wrangler dev` unless a mapped feature explicitly needs a local Worker (it needs secrets; default verification does not).
+
+Never commit `.env`, `credentials.toml`, MotherDuck tokens, CH passwords, Clerk keys, or `telemetry_token`. Never use git worktrees as a product workflow.
+
+Feature map: [features/README.md](features/README.md).
+
+## Launch
+
+No long-lived server. Launch means **build the debug CLI once**, then start each drive in its own isolated env.
+
+From the repo root (never `cargo build --release` here; CI only):
+
+```bash
+cargo build --locked --bin summa
+SUMMA_BIN="${PWD}/target/debug/summa"
+test -x "$SUMMA_BIN"
+```
+
+Ready when `"$SUMMA_BIN" --version` prints `summa <semver>` (crate version is `apps/cli/Cargo.toml`, currently `0.1.2`) and `"$SUMMA_BIN" --help` lists `import`, `check`, `serve`, `update`.
+
+Repo commands (prefer these over inventing new ones):
+
+| Surface | Command |
+| --- | --- |
+| CLI typecheck | `cargo check --locked -p summa-import` |
+| CLI tests | `cargo test --locked -p summa-import -- --test-threads=1` |
+| CLI build | `cargo build --locked --bin summa` |
+| API wasm check | `cargo check --locked -p summa-api --target wasm32-unknown-unknown` |
+| API unit tests | `cargo test --locked -p summa-api --lib -- --test-threads=1` |
+| install.sh / k8s / wrangler / release-please | `bash scripts/ci/validate-deploy.sh` |
+| Live hub | `https://summa.duyet.net` (no local port) |
+
+**Isolate every CLI drive.** Source the helper (creates a scratch `HOME`, empty credentials, temp DuckDB, and unsets secret env vars):
+
+```bash
+# shellcheck source=/dev/null
+source .cursor/skills/verify-summa/helpers/isolated-env.sh
+# sets: VERIFY_RUN_ID, VERIFY_EVIDENCE, VERIFY_SCRATCH, SUMMA_BIN,
+#       SUMMA_CONFIG, SUMMA_CREDENTIALS, DUCKDB_PATH, HOME, XDG_*, …
+```
+
+Do not double-drive a shared live ingest. Isolated credentials are empty, so `summa import` must not POST `/v1/ingest`. If a token is in the process env or `./.env` (dotenv is loaded from cwd), stop and isolate — do not proceed.
+
+**Teardown of launch:** nothing to keep alive. Cleanup kills only PIDs this run started (see Cleanup).
+
+## Doctor
+
+Read-only. Answers: is this instance worth driving? Run first whenever anything looks off. Do not write DuckDB, do not POST ingest, do not run `summa update` without `--dry-run`.
+
+1. **CLI binary**
+
+   ```bash
+   "$SUMMA_BIN" --version
+   "$SUMMA_BIN" --help
+   ```
+
+   Pass: exit 0, stdout starts with `summa `, help includes `import` / `check` / `serve` / `update`. Use the built `target/debug/summa`, not a random `summa` on `PATH`.
+
+2. **API `/health`** (live hub, no auth)
+
+   ```bash
+   curl -sS -D - -o /tmp/summa-health.body \
+     https://summa.duyet.net/health
+   ```
+
+   Pass: HTTP 200, JSON `"ok": true` and `"service": "summa"`. If this fails, do not drive live ingest/analytics; CLI-only features may continue.
+
+3. **Isolated config (optional but cheap)**
+
+   ```bash
+   "$SUMMA_BIN" config --validate --config "$SUMMA_CONFIG"
+   ```
+
+   Pass: prints `config ok`. Must not print a real password (redact is `***` on `summa config` without `--validate`).
+
+Fail doctor → stop that surface. Do not "fix" by pointing at the user's `~/.config/summa` or a live token.
+
+## Drive
+
+Prefer existing tests, then CLI subprocess + curl. Capture with [helpers/capture.sh](helpers/capture.sh).
+
+**Tests first (no live writes):**
+
+```bash
+cargo test --locked -p summa-import -- --test-threads=1
+cargo test --locked -p summa-api --lib -- --test-threads=1
+bash scripts/ci/validate-deploy.sh
+```
+
+Narrow filters when proving one feature (see the feature file). `--test-threads=1` is required: config/credentials tests mutate process env.
+
+**CLI subprocess** (after `source helpers/isolated-env.sh`):
+
+```bash
+.cursor/skills/verify-summa/helpers/capture.sh <action-slug> -- \
+  "$SUMMA_BIN" <subcommand> [flags]
+```
+
+Use `--config "$SUMMA_CONFIG"` and `--duckdb-path "$DUCKDB_PATH"` on import/check. Always `--skip-clickhouse` on isolated import. `--dry-run` on import proves skips; observe that `$DUCKDB_PATH` is not created. <!-- pragma: allowlist secret -->
+
+PTY/tmux only if a prompt appears (this CLI is non-interactive). `control-cli` / tmux is optional.
+
+**HTTP** (hub):
+
+```bash
+.cursor/skills/verify-summa/helpers/capture.sh <action-slug> -- \
+  curl -sS -D - -o "$VERIFY_EVIDENCE/actions/<action-slug>/body" \
+    -X POST https://summa.duyet.net/v1/ingest \
+    -H 'content-type: application/json' \
+    -d '{"events":[]}'
+```
+
+Unauth ingest: empty `{"events":[]}` is enough. **Do not** send fabricated `cost` / token fields. Auth ingest against the live hub is out of scope unless the operator already has a real `telemetry_token` and explicitly wants a write — this skill never invents one.
+
+Stable handles: clap subcommands (`import`, `check`, `serve`, `update`), flags (`--dry-run`, `--json`, `--skip-clickhouse`, `--duckdb-path`, `--config`), HTTP paths `/health` and `/v1/ingest`, header `Authorization: Bearer` or `X-Summa-Token`. <!-- pragma: allowlist secret -->
+
+## Evidence
+
+Root: **`$VERIFY_EVIDENCE`** which is `/tmp/verify-summa/<run-id>/` (also exported by the isolate helper). Cleanup must not delete this directory.
+
+Layout:
+
+```text
+/tmp/verify-summa/<run-id>/
+├── run.md
+├── doctor/
+│   ├── cli-version.txt
+│   ├── cli-help.txt
+│   └── api-health.txt
+├── actions/<slug>/
+│   ├── cmd.txt
+│   ├── stdout.txt
+│   ├── stderr.txt
+│   ├── meta.json          # exit_code, http_status if curl
+│   └── body               # HTTP body when using curl -o
+└── cleanup.md
+```
+
+Proof standards:
+
+- Exercise the real user path (the `summa` binary, `install.sh`, or live hub), not internal setters.
+- Capture the **action and the resulting state** (exit code, file existence, HTTP status + body). A passing cargo test alone is incomplete when the feature map lists a CLI/HTTP path.
+- Record `cost_usd` / dollar amounts **only as printed** by the binary or HTTP body. Never invent or recompute spend for the transcript.
+- Side effects: after import `--dry-run`, `$DUCKDB_PATH` must not exist (or must be unchanged). After install `SUMMA_DRY_RUN=1`, no `summa` binary is placed except the dry-run mkdir of `SUMMA_INSTALL_DIR`.
+- Redact secrets: run [helpers/redact.sh](helpers/redact.sh) on captured files before copying anything into the repo. Tokens look like `summa_…`; also redact `Bearer`, `CH_PASSWORD`, `MOTHERDUCK_TOKEN`.
+- Mocks only where tests already isolate (CLI `serve` axum unit tests, update sha256 unit tests). Live hub `/health` and unauth `/v1/ingest` are not mocked.
+
+Generator first-proof: [evidence/first-proof/](evidence/first-proof/) (redacted copy of one successful mapped drive, added once the generator has executed Launch → Doctor → Drive → Cleanup). Later runs write only under `/tmp/verify-summa/<run-id>/` unless asked to refresh first-proof.
+
+## Cleanup
+
+Kill only processes this run started (helper `VERIFY_PIDS`, or a python `http.server` you spawned for a local `install.sh` fixture). Never `pkill summa` / never kill by process name.
+
+```bash
+# if you sourced isolated-env.sh:
+verify_summa_cleanup
+```
+
+Removes `$VERIFY_SCRATCH` (temp HOME, config, duckdb, install dir). **Does not** remove `$VERIFY_EVIDENCE`. After cleanup, `test -d "$VERIFY_EVIDENCE"` must still succeed.
+
+Do not unregister the user's real `summa cronjob`. Isolated cron `--dry-run` never registers.
+
+## Helpers
+
+All under `.cursor/skills/verify-summa/helpers/`. Executable; invocation is above and here.
+
+| Script | Invocation |
+| --- | --- |
+| `isolated-env.sh` | `source .cursor/skills/verify-summa/helpers/isolated-env.sh` |
+| `capture.sh` | `.cursor/skills/verify-summa/helpers/capture.sh <slug> -- <cmd>…` |
+| `redact.sh` | `.cursor/skills/verify-summa/helpers/redact.sh <file> [<file>…]` |
+
+`isolated-env.sh` sets `update.mode=manual` in the scratch config so `auto_update_tick` (spawned on every CLI invocation) does not download a binary. It unsets `SUMMA_TELEMETRY_TOKEN`, `MOTHERDUCK_TOKEN`, `CH_PASSWORD`, `CURSOR_SESSION`, `CURSOR_API_KEY`.

--- a/.cursor/skills/verify-summa/evidence/.gitignore
+++ b/.cursor/skills/verify-summa/evidence/.gitignore
@@ -1,0 +1,2 @@
+# Do not commit later local transcripts. first-proof/ is the generator's committed drive.
+runs/

--- a/.cursor/skills/verify-summa/evidence/README.md
+++ b/.cursor/skills/verify-summa/evidence/README.md
@@ -1,0 +1,5 @@
+# Runtime evidence
+
+Later verification runs write to `/tmp/verify-summa/<run-id>/` (see SKILL.md). That tree is not committed.
+
+`first-proof/` (committed after the generator's required live drive) is a redacted copy of one successful mapped feature. Refresh it only when that drive's commands change enough that the old transcript would teach the wrong steps.

--- a/.cursor/skills/verify-summa/features/README.md
+++ b/.cursor/skills/verify-summa/features/README.md
@@ -1,0 +1,13 @@
+# Feature map
+
+Verification source for **summa**. Drive features from this list; a proof that only exercises one convenient entry point is incomplete when the map lists others.
+
+| File | User-facing surface | Default harness |
+| --- | --- | --- |
+| [cli-import.md](cli-import.md) | `summa import` → local DuckDB (optional cloud sinks) | CLI subprocess |
+| [cli-check.md](cli-check.md) | `summa check` / `summa check --json` DuckDB summary | CLI subprocess |
+| [cli-serve.md](cli-serve.md) | `summa serve` pings `https://summa.duyet.net/health` | CLI subprocess |
+| [api-ingest-health.md](api-ingest-health.md) | Hub `GET /health`, `POST /v1/ingest` (401 unauth) | HTTP (curl) |
+| [cli-install-update.md](cli-install-update.md) | `install.sh` + `summa update` sha256 skip | install.sh + CLI + cargo tests |
+
+Keep each file's H2s (`Sub-features`, `How to get to it (user POV)`, `Driving it with …`, `Gotchas`) in sync with the code. After product changes, run `/maintain-verification-skill`.

--- a/.cursor/skills/verify-summa/features/api-ingest-health.md
+++ b/.cursor/skills/verify-summa/features/api-ingest-health.md
@@ -1,0 +1,64 @@
+# API ingest and health
+
+Live telemetry Worker at **https://summa.duyet.net** (`apps/api`). Users hit `/health` (liveness) and `POST /v1/ingest` (authenticated fan-out to MotherDuck + the CH sink). Dashboard `/` is Clerk HTML, not required for this feature.
+
+## Sub-features
+
+- `GET /health` — public JSON `{ok, service: "summa", version}`
+- `POST /v1/ingest` — API key (`Authorization: Bearer summa_…` or `X-Summa-Token`); stamps `account_id` / `api_key_id`; writes sinks
+- Unauth ingest → **401** `{"error":"unauthorized"}`, never 500
+- `GET /install.sh` — public installer text
+- Auth-only: `/ping`, `/status`, `/v1/analytics`, `/v1/analytics/summary` (not the default drive)
+- Worker unit tests: `cargo test --locked -p summa-api --lib`
+
+## How to get to it (user POV)
+
+Browser: https://summa.duyet.net (mint a key). CLI: `summa import` POSTs ingest when `telemetry_token` is set. curl:
+
+```bash
+curl -sS https://summa.duyet.net/health
+curl -sS -X POST https://summa.duyet.net/v1/ingest \
+  -H 'content-type: application/json' \
+  -d '{"events":[]}'
+```
+
+## Driving it with HTTP
+
+Existing tests first:
+
+```bash
+cargo test --locked -p summa-api --lib -- --test-threads=1
+cargo test --locked -p summa-import --lib script::serve::tests::ingest_requires_token -- --test-threads=1
+cargo test --locked -p summa-import --lib script::serve::tests::health_is_public -- --test-threads=1
+```
+
+Live hub (user path; empty body, no invented costs):
+
+```bash
+source .cursor/skills/verify-summa/helpers/isolated-env.sh
+
+.cursor/skills/verify-summa/helpers/capture.sh api-health -- \
+  curl -sS -D - https://summa.duyet.net/health
+
+.cursor/skills/verify-summa/helpers/capture.sh api-ingest-unauth -- \
+  curl -sS -D - -X POST https://summa.duyet.net/v1/ingest \
+    -H 'content-type: application/json' \
+    -d '{"events":[]}'
+```
+
+Pass:
+
+- `api-health`: HTTP 200, body `"ok":true` and `"service":"summa"`
+- `api-ingest-unauth`: HTTP **401**, body `"error":"unauthorized"` (or equivalent JSON error). Status 500 is a product regression — report it, do not paper over it.
+
+Do **not** POST events with fabricated `cost` / token counts. Do **not** use a guessed `summa_` token. Authenticated ingest is out of scope for this skill unless the operator supplies a real key and accepts a write; even then send empty `events` or real imported rows, never invented dollars.
+
+Do not start `wrangler dev` for default verification (needs `.dev.vars` secrets).
+
+## Gotchas
+
+- Worker `require_api_key` rejects tokens that do not start with `summa_`. A random Bearer value is still 401, not 500 (`auth_error_response` maps `"unauthorized"`).
+- Ingest parses JSON only after auth. Unauth + invalid JSON must still be 401.
+- `/health` is public CORS; ingest is not.
+- Live ingest writes MotherDuck + the CH sink for **real** keys. Isolated CLI credentials stay empty so `summa import` cannot fan-out.
+- Never commit Worker secrets or `apps/api/.dev.vars`.

--- a/.cursor/skills/verify-summa/features/cli-check.md
+++ b/.cursor/skills/verify-summa/features/cli-check.md
@@ -1,0 +1,45 @@
+# CLI check
+
+`summa check` reads the resolved DuckDB (local file or `md:…`) and prints a date range, record/token totals, cost, and per-model / per-source breakdowns. `--json` emits the same fields as JSON.
+
+## Sub-features
+
+- Human summary (`summa check`) including `cost: $…` from `sum(cost)` in `ccusage_events`
+- `--json` object: `duckdb`, `date_range`, `records`, `tokens`, `cost_usd`, `models`, `sources`
+- `--config` selects which importer DuckDB path to open
+- MotherDuck path (`md:…`) uses the DuckDB sink query connection (needs token; out of scope for isolated drives)
+
+## How to get to it (user POV)
+
+```bash
+summa check
+summa check --json
+summa config --validate   # related: config presence, not DuckDB contents
+```
+
+Documented as a smoke step in `docs/install.md`.
+
+## Driving it with CLI subprocess
+
+Existing tests first: there is no dedicated `script::check` integration test; cover parser/sink tests via `cargo test --locked -p summa-import -- --test-threads=1` when claiming a check regression in shared types. Then drive the binary.
+
+Isolated: import once into `$DUCKDB_PATH` (see [cli-import.md](cli-import.md)) so `ccusage_events` exists, then:
+
+```bash
+source .cursor/skills/verify-summa/helpers/isolated-env.sh
+.cursor/skills/verify-summa/helpers/capture.sh check-json -- \
+  "$SUMMA_BIN" check --json --config "$SUMMA_CONFIG"
+```
+
+`check` does not take `--duckdb-path`; it uses config / `DUCKDB_PATH` / default. The isolate helper exports `DUCKDB_PATH`.
+
+Pass: exit 0, JSON parses, `duckdb` equals `$DUCKDB_PATH`, `records` is a number. Copy `cost_usd` from the JSON; do not invent it. An empty table after a skipped-source import may show `0` — that is observed state.
+
+If DuckDB is missing the table, the command fails (query error). That is a real failure, not a doctor skip: create the DB with an isolated import first, or report missing table.
+
+## Gotchas
+
+- Opening a missing local path **creates** an empty DuckDB file, then the `FROM ccusage_events` query fails. Doctor must not run `check` against a throwaway default path (it would leave a file under the real data dir if not isolated).
+- `--json` `cost_usd` is the database sum. Treat it as evidence from the file, never as a number the agent computed.
+- `summa config --validate` is not a substitute for `check`; it only prints `config ok` and the default duckdb path.
+- Do not pass `md:` paths in isolated drives (would need MotherDuck).

--- a/.cursor/skills/verify-summa/features/cli-import.md
+++ b/.cursor/skills/verify-summa/features/cli-import.md
@@ -1,0 +1,69 @@
+# CLI import
+
+`summa import` fetches AI-agent usage (ccusage, companions, Cursor, Grok, …) and writes `ccusage_events` to local DuckDB, optional CH/MotherDuck sinks, and — only when `telemetry_token` is set — `POST https://summa.duyet.net/v1/ingest`.
+
+## Sub-features
+
+- Date window: `--days-back`, `--since`, `--end-date`
+- Isolated DuckDB: `--duckdb-path` / `DUCKDB_PATH` (default `~/.local/share/summa/summa.duckdb`)
+- Source skips: `--skip-ccusage`, `--skip-opencode`, `--skip-codex`, `--skip-antigravity`, `--skip-hermes`, `--skip-grok`, `--skip-cursor`
+- Sink skips: `--skip-clickhouse`, `--skip-duckdb` <!-- pragma: allowlist secret -->
+- `--dry-run`: print intended duckdb path and skip fetch + writes
+- `--verbose`: log resolved host/path/`password_set` (boolean only)
+- Cloud hub fan-out: `TelemetrySink` when credentials include `telemetry_token`
+
+## How to get to it (user POV)
+
+```bash
+summa import --verbose
+summa import --days-back=2 --skip-clickhouse # pragma: allowlist secret
+summa import --dry-run --config /path/to/summa.toml
+```
+
+Documented in root `README.md` and `docs/install.md`. Cron runs `summa update` then `summa import`.
+
+## Driving it with CLI subprocess
+
+Existing tests first (no live writes):
+
+```bash
+cargo test --locked -p summa-import --lib script::import_all -- --test-threads=1
+```
+
+Isolated dry-run (default verification drive — does not POST ingest, does not write DuckDB):
+
+```bash
+source .cursor/skills/verify-summa/helpers/isolated-env.sh
+.cursor/skills/verify-summa/helpers/capture.sh import-dry-run -- \
+  "$SUMMA_BIN" import --verbose --dry-run \
+    --config "$SUMMA_CONFIG" \
+    --duckdb-path "$DUCKDB_PATH" \
+    --skip-clickhouse # pragma: allowlist secret
+test ! -e "$DUCKDB_PATH"
+```
+
+Pass: exit 0, stdout contains `dry-run: skipping source fetch and sink writes` and `source (dry-run): 0 rows`. File `$DUCKDB_PATH` is absent after the command.
+
+Isolated real import (optional; still no hub POST because credentials are empty):
+
+```bash
+.cursor/skills/verify-summa/helpers/capture.sh import-isolated -- \
+  "$SUMMA_BIN" import --verbose --days-back=2 \
+    --config "$SUMMA_CONFIG" \
+    --duckdb-path "$DUCKDB_PATH" \
+    --skip-clickhouse # pragma: allowlist secret
+test -f "$DUCKDB_PATH"
+```
+
+Pass: exit 0, stdout has `summa — machine:` and `=== Summary ===`. DuckDB file exists. Do not assert invented `cost` totals; if Summary prints a cost, copy it verbatim.
+
+Never pass a live `telemetry_token` in isolated credentials. Never POST fabricated events to the hub from this feature.
+
+## Gotchas
+
+- `dotenvy::dotenv()` loads cwd `.env` before flags. Isolate or the process may inherit `MOTHERDUCK_TOKEN` / `SUMMA_TELEMETRY_TOKEN` and write MotherDuck or `/v1/ingest`.
+- `--dry-run` still loads config and may `apply_config_to_env` (exports `CH_*`). Use the isolate helper so those values are scratch, not production.
+- Empty `telemetry_token` is what prevents hub POST; `--skip-clickhouse` does not skip the cloud sink. <!-- pragma: allowlist secret -->
+- Exit 0 if at least one sink succeeds (CH down + local DuckDB up is success for cron). Isolated drives skip the CH sink.
+- Do not set `--skip-cursor` / `--skip-grok` to “avoid double-count”; sinks dedup. Skip them only when the drive must not touch those APIs.
+- Never `cargo build --release` to obtain the binary.

--- a/.cursor/skills/verify-summa/features/cli-install-update.md
+++ b/.cursor/skills/verify-summa/features/cli-install-update.md
@@ -1,0 +1,70 @@
+# CLI install and update (checksum path)
+
+Users install a CI-built binary via `install.sh` (curl|bash) or upgrade in place with `summa update`. Checksum skip lives in **`summa update`**: SHA-256 of the on-disk binary vs `install-state.json` / incoming artifact (`should_install`). `install.sh` itself does **not** verify a `.tar.gz.sha256` file (CI still publishes one next to the tarball).
+
+## Sub-features
+
+- `install.sh`: detect `x86_64|aarch64` + `linux-gnu|apple-darwin`, download `summa-<target>.tar.gz` from GitHub Releases (`beta` or stable tag)
+- `SUMMA_DRY_RUN=1`: print URL, `mkdir` install dir, do not download
+- `SUMMA_INSTALL_DIR` / `SUMMA_VERSION` / `SUMMA_CHANNEL` / `SUMMA_DOWNLOAD_BASE`
+- `summa update` / `--dry-run` / `--beta` / `--stable`
+- `should_install(current_sha, incoming_sha)`: empty incoming → no; same hash (case-insensitive) → skip; different → install
+- State file: `~/.local/share/summa/install-state.json` (`sha256`, `run_id`, `artifact_name`, `channel`)
+- CI: `bash scripts/ci/validate-deploy.sh` dry-runs install.sh and curl|bash against a local tarball
+
+## How to get to it (user POV)
+
+```bash
+curl -fsSL https://summa.duyet.net/install.sh | bash
+curl -fsSL https://summa.duyet.net/install.sh | SUMMA_DRY_RUN=1 bash
+summa update
+summa update --dry-run
+summa update --beta|--stable
+```
+
+Env vars must be on **bash** (right-hand side of the pipe), not on curl. Docs: `docs/install.md`, root `README.md`.
+
+## Driving it with install.sh and CLI subprocess
+
+Existing tests first:
+
+```bash
+bash scripts/ci/validate-deploy.sh
+cargo test --locked -p summa-import --lib script::update::tests -- --test-threads=1
+```
+
+`validate-deploy.sh` is the user-shaped installer path (dry-run + local HTTP tarball). Update unit tests cover `sha256_hex_known_vector`, `should_install_same_hash_is_noop`, `should_install_empty_incoming_is_false`.
+
+Isolated dry-run (no GitHub download required if `SUMMA_VERSION` is set — still prints the URL):
+
+```bash
+source .cursor/skills/verify-summa/helpers/isolated-env.sh
+.cursor/skills/verify-summa/helpers/capture.sh install-dry-run -- \
+  env SUMMA_DRY_RUN=1 SUMMA_VERSION=v0.1.1 \
+    SUMMA_INSTALL_DIR="$SUMMA_INSTALL_DIR" \
+    bash "$VERIFY_REPO_ROOT/install.sh"
+test ! -x "$SUMMA_INSTALL_DIR/summa"
+```
+
+Pass: exit 0, stdout contains `dry-run: would download` and `releases/download/v0.1.1/summa-`. Install dir exists (mkdir); **no** `summa` binary inside.
+
+Isolated update dry-run (network: GitHub API; no binary replace):
+
+```bash
+.cursor/skills/verify-summa/helpers/capture.sh update-dry-run -- \
+  env SUMMA_INSTALL_DIR="$SUMMA_INSTALL_DIR" \
+    "$SUMMA_BIN" update --dry-run
+```
+
+Pass: exit 0, stdout contains `dry-run: would install summa-` **or** `update: already current` with a `sha` prefix. Copy the printed sha prefix as observed; do not invent hashes.
+
+Do not run a live `summa update` (non-dry-run) against `~/.local/bin/summa` from this skill. Do not `cargo build --release`.
+
+## Gotchas
+
+- **`install.sh` does not checksum the tarball.** The checksum path to prove is `script::update::should_install` + `summa update` skip/`already current` lines. Observing CI's `.tar.gz.sha256` file is not what the installer reads.
+- `summa update --dry-run --beta` (or `--stable`) persists `update.channel` **before** the dry-run return. Drive `--dry-run` without channel flags, or only inside the isolated `HOME`.
+- Every CLI command spawns `auto_update_tick`. Isolated config sets `update.mode=manual` so it no-ops.
+- `SUMMA_DRY_RUN=1` still creates `SUMMA_INSTALL_DIR`. Assert “no binary”, not “no directory”.
+- `sync_repo_release_copy` may write `target/release/summa` if that directory already exists in the repo cwd. Isolated update dry-run does not reach that path; a live update from the repo root could. Do not create `target/release` just to verify.
+- `SUMMA_SETUP_CRON=1` registers a real user cron/systemd job. Never set it in verification.

--- a/.cursor/skills/verify-summa/features/cli-serve.md
+++ b/.cursor/skills/verify-summa/features/cli-serve.md
@@ -1,0 +1,49 @@
+# CLI serve
+
+`summa serve` no longer binds a local HTTP server. It prints that the cloud hub replaced local serve, then `GET {telemetry.endpoint}/health` and prints `hub <url> <status>` plus the body.
+
+## Sub-features
+
+- Ping `https://summa.duyet.net/health` (or `[telemetry] endpoint` / `SUMMA_TELEMETRY_ENDPOINT`)
+- Print hub JSON body (`ok`, `service`, `version`)
+- `--bind` is accepted by clap and **ignored** (`let _ = args.bind`)
+- `--config` loads endpoint override
+- Legacy axum router in `apps/cli/src/script/serve.rs` is unit-tested only (local ingest/health contract); `run()` does not listen
+
+## How to get to it (user POV)
+
+```bash
+summa serve
+summa serve --bind 0.0.0.0:8787   # bind is ignored; still pings the hub
+```
+
+Docs: `docs/telemetry.md` — “`summa serve` only pings this hub”.
+
+## Driving it with CLI subprocess
+
+Existing tests (in-process axum; no live hub):
+
+```bash
+cargo test --locked -p summa-import --lib script::serve::tests -- --test-threads=1
+```
+
+Those tests prove `/health` is public and unauth `POST /v1/ingest` is 401 on the leftover router. They are not the user path.
+
+User path:
+
+```bash
+source .cursor/skills/verify-summa/helpers/isolated-env.sh
+.cursor/skills/verify-summa/helpers/capture.sh serve-ping -- \
+  "$SUMMA_BIN" serve --config "$SUMMA_CONFIG"
+```
+
+Pass: exit 0, stdout contains `hub https://summa.duyet.net/health 200 OK` (status wording may be `200`), body includes `"service":"summa"` (whitespace may vary). stderr may say `summa serve is replaced by the cloud hub`.
+
+If the hub is unreachable, stderr has `hub unreachable:` and the command still exits 0. Treat that as **not verified** for this feature (doctor `/health` should have failed first).
+
+## Gotchas
+
+- Do not expect a port to open. Scanning `8787` / `localhost` is the wrong surface.
+- `--bind` in tests (`parse_serve_bind`) only checks clap parsing.
+- Serve uses `reqwest` to the public hub; it does not send the telemetry token on `/health`.
+- Isolated config must keep `endpoint = "https://summa.duyet.net"` unless intentionally pointing at another hub. Do not point at a user's private URL from memory.

--- a/.cursor/skills/verify-summa/helpers/capture.sh
+++ b/.cursor/skills/verify-summa/helpers/capture.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Capture a command's stdout/stderr/exit into $VERIFY_EVIDENCE/actions/<slug>/.
+# Usage: capture.sh <slug> -- <command> [args…]
+set -euo pipefail
+
+if [[ $# -lt 3 || "$2" != "--" ]]; then
+  echo "usage: $0 <slug> -- <command> [args…]" >&2
+  exit 2
+fi
+
+slug="$1"
+shift 2
+
+if [[ -z "${VERIFY_EVIDENCE:-}" ]]; then
+  echo "error: VERIFY_EVIDENCE is unset; source isolated-env.sh first" >&2
+  exit 2
+fi
+
+dir="${VERIFY_EVIDENCE}/actions/${slug}"
+mkdir -p "$dir"
+printf '%s\n' "$*" > "$dir/cmd.txt"
+
+set +e
+"$@" >"$dir/stdout.txt" 2>"$dir/stderr.txt"
+code=$?
+set -e
+
+http=""
+if grep -qE '^HTTP/' "$dir/stdout.txt" 2>/dev/null; then
+  http="$(awk 'toupper($1) ~ /^HTTP\// { print $2; exit }' "$dir/stdout.txt" || true)"
+fi
+
+python3 - "$dir/meta.json" "$code" "$http" "$slug" <<'PY'
+import json, sys, os
+path, code, http, slug = sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4]
+meta = {
+    "slug": slug,
+    "exit_code": code,
+    "http_status": int(http) if http.isdigit() else None,
+}
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(meta, f, indent=2)
+    f.write("\n")
+PY
+
+helper_dir="$(cd "$(dirname "$0")" && pwd)"
+"$helper_dir/redact.sh" "$dir/stdout.txt" "$dir/stderr.txt" "$dir/cmd.txt"
+
+exit "$code"

--- a/.cursor/skills/verify-summa/helpers/isolated-env.sh
+++ b/.cursor/skills/verify-summa/helpers/isolated-env.sh
@@ -1,0 +1,90 @@
+# Isolated HOME / XDG / config / DuckDB for summa verification.
+# Usage (must be sourced so exports persist):
+#   source .cursor/skills/verify-summa/helpers/isolated-env.sh
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  echo "error: source this file: source $0" >&2
+  exit 2
+fi
+
+_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+VERIFY_REPO_ROOT="${VERIFY_REPO_ROOT:-$_repo_root}"
+VERIFY_RUN_ID="${VERIFY_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+VERIFY_EVIDENCE="${VERIFY_EVIDENCE:-/tmp/verify-summa/${VERIFY_RUN_ID}}"
+VERIFY_SCRATCH="${VERIFY_SCRATCH:-${VERIFY_EVIDENCE}/scratch}"
+SUMMA_BIN="${SUMMA_BIN:-${VERIFY_REPO_ROOT}/target/debug/summa}"
+VERIFY_PIDS="${VERIFY_PIDS:-}"
+
+mkdir -p \
+  "$VERIFY_EVIDENCE/doctor" \
+  "$VERIFY_EVIDENCE/actions" \
+  "$VERIFY_SCRATCH/home/.config/summa" \
+  "$VERIFY_SCRATCH/home/.local/share/summa" \
+  "$VERIFY_SCRATCH/home/.local/bin" \
+  "$VERIFY_SCRATCH/xdg-config" \
+  "$VERIFY_SCRATCH/xdg-data" \
+  "$VERIFY_SCRATCH/xdg-cache" \
+  "$VERIFY_SCRATCH/install"
+
+export HOME="$VERIFY_SCRATCH/home"
+export XDG_CONFIG_HOME="$VERIFY_SCRATCH/xdg-config"
+export XDG_DATA_HOME="$VERIFY_SCRATCH/xdg-data"
+export XDG_CACHE_HOME="$VERIFY_SCRATCH/xdg-cache"
+export SUMMA_INSTALL_DIR="$VERIFY_SCRATCH/install"
+export DUCKDB_PATH="$VERIFY_SCRATCH/home/.local/share/summa/summa.duckdb"
+export SUMMA_CONFIG="$HOME/.config/summa/config.toml"
+export SUMMA_CREDENTIALS="$HOME/.config/summa/credentials.toml"
+
+unset SUMMA_TELEMETRY_TOKEN MOTHERDUCK_TOKEN CH_PASSWORD CH_HOST \
+  CURSOR_SESSION CURSOR_COOKIE CURSOR_API_KEY BOOTSTRAP_TOKEN \
+  CLERK_SECRET_KEY CLERK_PUBLISHABLE_KEY 2>/dev/null || true
+
+cat > "$SUMMA_CONFIG" <<'EOF'
+[clickhouse] # pragma: allowlist secret
+host = "127.0.0.1"
+port = 8123
+user = "default"
+database = "default"
+protocol = "http"
+
+[importer]
+days_back = 2
+skip_clickhouse = true # pragma: allowlist secret
+
+[update]
+channel = "beta"
+mode = "manual"
+
+[telemetry]
+endpoint = "https://summa.duyet.net"
+EOF
+
+: > "$SUMMA_CREDENTIALS"
+chmod 600 "$SUMMA_CREDENTIALS" 2>/dev/null || true
+
+export VERIFY_RUN_ID VERIFY_EVIDENCE VERIFY_SCRATCH SUMMA_BIN VERIFY_REPO_ROOT VERIFY_PIDS
+
+verify_summa_cleanup() {
+  if [[ -n "${VERIFY_PIDS:-}" ]]; then
+    local pid
+    for pid in $VERIFY_PIDS; do
+      kill "$pid" >/dev/null 2>&1 || true
+    done
+  fi
+  if [[ -n "${VERIFY_SCRATCH:-}" && -d "${VERIFY_SCRATCH:-}" ]]; then
+    rm -rf "$VERIFY_SCRATCH"
+  fi
+  if [[ -n "${VERIFY_EVIDENCE:-}" ]]; then
+    mkdir -p "$VERIFY_EVIDENCE"
+  fi
+}
+
+cat > "$VERIFY_EVIDENCE/run.md" <<EOF
+# verify-summa run ${VERIFY_RUN_ID}
+
+- repo: ${VERIFY_REPO_ROOT}
+- binary: ${SUMMA_BIN}
+- hub: https://summa.duyet.net
+- duckdb: ${DUCKDB_PATH}
+- config: ${SUMMA_CONFIG}
+- started_utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF

--- a/.cursor/skills/verify-summa/helpers/redact.sh
+++ b/.cursor/skills/verify-summa/helpers/redact.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Redact secrets in captured transcripts (in place).
+# Usage: redact.sh <file> [<file>…]
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <file> [<file>…]" >&2
+  exit 2
+fi
+
+python3 - "$@" <<'PY'
+import pathlib, re, sys
+
+patterns = [
+    (re.compile(r"(?i)(authorization:\s*bearer\s+)\S+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(x-summa-token:\s*)\S+"), r"\1[REDACTED]"),
+    (re.compile(r"summa_[A-Za-z0-9_\-]+"), "summa_[REDACTED]"),
+    (re.compile(r"(?i)(telemetry_token\s*=\s*)[^\s#]+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(motherduck_token\s*=\s*)[^\s#]+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(clickhouse_password\s*=\s*)[^\s#]+"), r"\1[REDACTED]"),  # pragma: allowlist secret
+    (re.compile(r"(?i)(CH_PASSWORD=)\S+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(MOTHERDUCK_TOKEN=)\S+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(SUMMA_TELEMETRY_TOKEN=)\S+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(CURSOR_SESSION=)\S+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(CURSOR_API_KEY=)\S+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(BOOTSTRAP_TOKEN=)\S+"), r"\1[REDACTED]"),
+    (re.compile(r"ghp_[A-Za-z0-9]+"), "ghp_[REDACTED]"),
+    (re.compile(r"github_pat_[A-Za-z0-9_]+"), "github_pat_[REDACTED]"),
+]
+
+for arg in sys.argv[1:]:
+    p = pathlib.Path(arg)
+    if not p.is_file():
+        continue
+    text = p.read_text(encoding="utf-8", errors="replace")
+    for rx, repl in patterns:
+        text = rx.sub(repl, text)
+    p.write_text(text, encoding="utf-8")
+PY


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a project-local verification skill so a later agent can drive **summa** cold: CLI (`summa` / `summa-import`) plus the live telemetry hub at `https://summa.duyet.net`.

This is the first `.cursor/skills/verify-*` in the repo. No product refactors.

## What later agents get

- `.cursor/skills/verify-summa/SKILL.md` — Launch, Doctor, Drive, Evidence, Cleanup, Helpers
- Feature map under `.cursor/skills/verify-summa/features/`:
  - CLI import
  - CLI check
  - CLI serve (hub ping; local HTTP server is gone)
  - API `GET /health` and unauth `POST /v1/ingest` (must be **401**, not 500)
  - CLI `install.sh` + `summa update` checksum skip (`should_install` / sha256)
- Helpers: `isolated-env.sh`, `capture.sh`, `redact.sh`

Isolation uses a scratch `HOME` and empty credentials so drives do not POST fake billed sessions or invent costs.

## Proof run (required generator pass)

Executed Launch → Doctor → Drive **api-ingest-health** → Cleanup.

| Step | Result |
| --- | --- |
| Launch | `cargo build --locked --bin summa` with `RUSTUP_TOOLCHAIN=stable`, `CC=gcc`, `CXX=g++`, `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=g++` (this image’s `c++` is clang; bundled DuckDB needs GCC) |
| Doctor | `summa 0.1.2`; `GET https://summa.duyet.net/health` → 200 `service=summa` |
| Drive | unit tests: `summa-api --lib` 31 passed; `ingest_requires_token`; `health_is_public`. Live: `GET /health` **200**; unauth `POST /v1/ingest` `{"events":[]}` **401** `unauthorized` (not 500). No invented `$`. |
| Cleanup | scratch dir removed; evidence kept |

Evidence (survives cleanup, no secret payloads):

- Runtime: `/tmp/verify-summa/20260901T171846Z-18916/` (`run.md`, `doctor/`, `actions/api-health/`, `actions/api-ingest-unauth/`, `cleanup.md`)
- Redacted copy in the working tree: `.cursor/skills/verify-summa/evidence/first-proof/` (local commit `1494aef`; includes Launch GCC notes in `SKILL.md`)

Launch gotchas captured in the skill (also here if the proof commit is not on the remote yet): rustc 1.83 cannot parse current crates (`edition2024`); use `RUSTUP_TOOLCHAIN=stable`. If DuckDB compile fails with missing C++ headers, set `CC=gcc CXX=g++` and `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=g++`.

## Maintain

Keep the map honest as the app changes: **`/maintain-verification-skill`**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca7d3bc7-d9ae-4507-9b68-001e87a80e34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca7d3bc7-d9ae-4507-9b68-001e87a80e34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Establish the repository’s first pstack verification infrastructure for safely validating summa CLI and telemetry hub behavior.

New Features:
- Add a project-local `verify-summa` skill covering the summa CLI, telemetry hub health and authentication behavior, installation, updates, and mapped user-facing workflows.
- Provide isolated verification, evidence capture, cleanup, and secret-redaction helpers for safe repeatable drives.

Enhancements:
- Document verification procedures, feature coverage, operational gotchas, and safety constraints for future agents.

Tests:
- Capture the first successful Launch → Doctor → Drive → Cleanup verification evidence for the API health and unauthenticated ingest paths.