### PR TITLE
fix(api): stop /v1/analytics 500s when D1 is missing

### DIFF
--- a/apps/api/src/analytics.rs
+++ b/apps/api/src/analytics.rs
@@ -48,11 +48,7 @@ pub fn inclusive_days(since: &str, until: &str) -> i64 {
     }
 }
 
-pub fn summarize(
-    since: &str,
-    until: &str,
-    points: &[AnalyticsPoint],
-) -> serde_json::Value {
+pub fn summarize(since: &str, until: &str, points: &[AnalyticsPoint]) -> serde_json::Value {
     let days = inclusive_days(since, until);
     let mut cost = 0.0;
     let mut total_tokens: u64 = 0;
@@ -85,14 +81,15 @@ pub fn summarize(
     })
 }
 
-pub async fn load_points(
-    env: &Env,
+/// Usage totals come from warehouse `ccusage_events`, never D1.
+pub fn usage_select_sql(
+    group: &str,
     account_id: &str,
     include_legacy: bool,
-    group: &str,
     since: &str,
     until: &str,
-) -> Result<Vec<AnalyticsPoint>> {
+    use_final: bool,
+) -> String {
     let extra = if group == "model" {
         "source, model_name"
     } else {
@@ -111,31 +108,47 @@ pub async fn load_points(
     } else {
         format!("account_id = {}", crate::types::sql_literal(account_id))
     };
-    let where_sql = format!(
-        "record_type = 'daily' AND date >= '{since}' AND date <= '{until}' AND {tenant}"
-    );
+    let where_sql =
+        format!("record_type = 'daily' AND date >= '{since}' AND date <= '{until}' AND {tenant}");
     let select = format!(
         "SELECT date, {extra}, sum(cost) AS cost, sum(total_tokens) AS total_tokens, sum(entries) AS entries \
          FROM ccusage_events"
     );
     let tail = format!(" WHERE {where_sql} GROUP BY {group_by} ORDER BY date, source");
+    if use_final {
+        format!("{select} FINAL{tail} FORMAT JSONEachRow")
+    } else {
+        format!("{select}{tail}")
+    }
+}
+
+pub async fn load_points(
+    env: &Env,
+    account_id: &str,
+    include_legacy: bool,
+    group: &str,
+    since: &str,
+    until: &str,
+) -> Result<Vec<AnalyticsPoint>> {
     let mut errors = Vec::new();
     if clickhouse_configured(env) {
-        let sql = format!("{select} FINAL{tail} FORMAT JSONEachRow");
+        let sql = usage_select_sql(group, account_id, include_legacy, since, until, true);
         match clickhouse_query(env, &sql).await {
             Ok(text) => return Ok(parse_analytics_payload(&text)),
             Err(e) => errors.push(format!("clickhouse: {e}")),
         }
     }
     if motherduck_configured(env) {
-        let sql = format!("{select}{tail}");
+        let sql = usage_select_sql(group, account_id, include_legacy, since, until, false);
         match motherduck_query(env, &sql).await {
             Ok(text) => return Ok(parse_analytics_payload(&text)),
             Err(e) => errors.push(format!("motherduck: {e}")),
         }
     }
     if errors.is_empty() {
-        return Err(worker::Error::RustError("no analytics sink configured".into()));
+        return Err(worker::Error::RustError(
+            "no analytics sink configured".into(),
+        ));
     }
     Err(worker::Error::RustError(errors.join("; ")))
 }
@@ -182,5 +195,37 @@ mod tests {
         assert_eq!(v["cost"], 10.0);
         assert_eq!(v["cost_per_day"], 1.0);
         assert_eq!(v["entries"], 2);
+    }
+
+    #[test]
+    fn usage_sql_reads_ccusage_events_not_d1() {
+        let ch = usage_select_sql("source", "acc-1", true, "2026-01-01", "2026-01-07", true);
+        assert!(ch.contains("FROM ccusage_events FINAL"));
+        assert!(ch.contains("FORMAT JSONEachRow"));
+        assert!(ch.contains("(account_id = 'acc-1' OR account_id = '')"));
+        let lower = ch.to_ascii_lowercase();
+        assert!(!lower.contains("from events"));
+        assert!(!lower.contains("api_keys"));
+        assert!(!lower.contains("from accounts"));
+
+        let md = usage_select_sql("model", "acc-2", false, "2026-02-01", "2026-02-02", false);
+        assert!(md.contains("FROM ccusage_events WHERE"));
+        assert!(!md.contains(" FINAL"));
+        assert!(!md.contains("FORMAT JSONEachRow"));
+        assert!(md.contains("account_id = 'acc-2'"));
+        assert!(md.contains("GROUP BY date, source, model_name"));
+        assert!(!md.contains("api_keys"));
+    }
+
+    #[test]
+    fn summary_from_store_fixture_does_not_invent_cost() {
+        let text = "{\"date\":\"2026-01-01\",\"source\":\"cursor\",\"cost\":2.5,\"total_tokens\":9,\"entries\":1}\n{\"date\":\"2026-01-01\",\"source\":\"grok\",\"cost\":1.25,\"total_tokens\":3,\"entries\":2}\n";
+        let points = parse_analytics_payload(text);
+        let v = summarize("2026-01-01", "2026-01-01", &points);
+        assert_eq!(v["cost"], 3.75);
+        assert_eq!(v["total_tokens"], 12);
+        assert_eq!(v["entries"], 3);
+        assert_eq!(v["cost_per_day"], 3.75);
+        assert_eq!(v["days"], 1);
     }
 }

--- a/apps/api/src/auth.rs
+++ b/apps/api/src/auth.rs
@@ -61,10 +61,6 @@ pub fn extract_bearer(req: &Request) -> String {
     token_from_headers(x_summa.as_deref(), authorization.as_deref())
 }
 
-fn unauthorized() -> Result<Response> {
-    Response::from_json(&serde_json::json!({"error": "unauthorized"})).map(|r| r.with_status(401))
-}
-
 pub async fn require_api_key(
     req: &Request,
     env: &Env,
@@ -129,14 +125,39 @@ pub fn auth_error_status(err: AuthError) -> u16 {
     }
 }
 
-pub fn auth_error_response(err: AuthError) -> Result<Response> {
+pub fn auth_error_body(err: AuthError) -> &'static str {
     match err {
-        AuthError::Unauthorized => unauthorized(),
-        AuthError::Unavailable => Response::from_json(&serde_json::json!({
-            "error": "auth unavailable"
-        }))
-        .map(|r| r.with_status(auth_error_status(err))),
+        AuthError::Unauthorized => "unauthorized",
+        AuthError::Unavailable => "auth unavailable",
     }
+}
+
+/// Map leftover `worker::Error` strings (D1 deleted/misbound) to a public body.
+/// Never returns the original message — bindings and database ids stay off the wire.
+pub fn public_error_for_worker(msg: &str) -> (u16, &'static str) {
+    if is_store_failure(msg) {
+        (
+            auth_error_status(AuthError::Unavailable),
+            auth_error_body(AuthError::Unavailable),
+        )
+    } else {
+        (500, "internal error")
+    }
+}
+
+pub fn is_store_failure(msg: &str) -> bool {
+    let lower = msg.to_ascii_lowercase();
+    lower.contains("auth unavailable")
+        || lower.contains("store unavailable")
+        || lower.contains("d1")
+        || (lower.contains("binding") && lower.contains("db"))
+        || (lower.contains("database")
+            && (lower.contains("deleted") || lower.contains("not found") || lower.contains("7404")))
+}
+
+pub fn auth_error_response(err: AuthError) -> Result<Response> {
+    Response::from_json(&serde_json::json!({ "error": auth_error_body(err) }))
+        .map(|r| r.with_status(auth_error_status(err)))
 }
 
 pub fn opt_secret(env: &Env, name: &str) -> String {
@@ -365,6 +386,32 @@ mod tests {
     #[test]
     fn auth_failures_are_not_500() {
         assert_eq!(auth_error_status(AuthError::Unauthorized), 401);
+        assert_eq!(auth_error_body(AuthError::Unauthorized), "unauthorized");
         assert_eq!(auth_error_status(AuthError::Unavailable), 503);
+        assert_eq!(auth_error_body(AuthError::Unavailable), "auth unavailable");
+    }
+
+    #[test]
+    fn missing_d1_does_not_leak_internals() {
+        let samples = [
+            "D1: D1Error { cause: JsValue(Error: D1 database 00000000-0000-0000-0000-000000000000 has been deleted.",
+            "Error 7404: The database could not be found",
+            "Binding `DB` not found",
+            "auth store unavailable",
+        ];
+        for sample in samples {
+            let (status, body) = public_error_for_worker(sample);
+            assert_eq!(status, 503, "{sample}");
+            assert_eq!(body, "auth unavailable");
+            let lower = body.to_ascii_lowercase();
+            assert!(!lower.contains("d1"), "{body}");
+            assert!(!lower.contains("deleted"), "{body}");
+            assert!(!lower.contains("7404"), "{body}");
+            assert!(!body.contains("00000000"), "{body}");
+            assert!(!body.contains('`'), "{body}");
+        }
+        let (status, body) = public_error_for_worker("wasm trap");
+        assert_eq!(status, 500);
+        assert_eq!(body, "internal error");
     }
 }

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -8,8 +8,8 @@ mod types;
 
 use analytics::{analytics_window, load_points, summarize};
 use auth::{
-    auth_error_response, is_owner_account, list_api_keys, mint_api_key, opt_var, require_api_key,
-    require_session, revoke_api_key,
+    auth_error_response, is_owner_account, list_api_keys, mint_api_key, opt_var,
+    public_error_for_worker, require_api_key, require_session, revoke_api_key,
 };
 use sinks::{collect_pings, fanout_write};
 use types::{
@@ -27,9 +27,10 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
     let public = matches!(req.path().as_str(), "/" | "/health" | "/install.sh");
     match route(req, env).await {
         Ok(res) => apply_cors(origin.as_deref(), public, res),
-        Err(_) => {
-            let res = Response::from_json(&serde_json::json!({"error": "internal error"}))?
-                .with_status(500);
+        Err(e) => {
+            let (status, error) = public_error_for_worker(&e.to_string());
+            let res =
+                Response::from_json(&serde_json::json!({ "error": error }))?.with_status(status);
             apply_cors(origin.as_deref(), public, res)
         }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## TL;DR

Authenticated `GET /v1/analytics` and `/v1/analytics/summary` currently 500 because API-key lookup hits a D1 binding whose database is gone. This PR fail-closes that path as **503 `{"error":"auth unavailable"}`** (no internals) and keeps session totals on warehouse `ccusage_events` (CH, then MotherDuck). Costs are never invented.

Unauth stays **401**. `/health` is unchanged.

## Cause

- D1 is **keys/accounts only**. Usage already lives in CH / MotherDuck (`ccusage_events`). Public burn.duyet.net still shows spend because it is on that warehouse path.
- Live worker `0.1.1` still copies the D1-deleted error into the JSON body for any `summa_` token.
- #109 already maps `require_api_key` D1 failures to 503; that build is not what is serving summa.duyet.net. Leftover `worker::Error` from other `?` paths still became a 500.
- In-repo `apps/api/wrangler.jsonc` `database_id` points at a D1 that is no longer on the Cloudflare account. That is an **ops** restore, not a SQL bug in analytics.

## Code

- Fetch catch-all sanitizes D1 / missing-binding errors → 503 `auth unavailable`. Other failures stay 500 `internal error`. The raw Worker message never goes on the wire.
- Analytics SQL is `usage_select_sql`: `FROM ccusage_events` only (FINAL + JSONEachRow for CH). No D1 `events` / `api_keys` read for totals.
- Missing or non-`summa_` token stays 401 before D1 is touched.

## Ops (required for 200s)

This PR stops the 500 leak. It cannot recreate the keys database.

After merge + deploy:

1. Create D1 named `summa-telemetry`.
2. Apply `apps/api/migrations` (`0001_init` + `0003_drop_events`).
3. Put the new `database_id` in `apps/api/wrangler.jsonc` and deploy.
4. Re-mint telemetry tokens (hashes lived in the deleted DB). An empty keys table will 401 existing tokens, which is fail-closed, not a restored session.

Until that happens, authenticated analytics should return **503**, not 500.

## Tests

- `missing_or_wrong_prefix_is_unauthorized` → 401
- `missing_d1_does_not_leak_internals` → 503, static body (no D1 / deleted / ids)
- `usage_sql_reads_ccusage_events_not_d1`
- `summary_from_store_fixture_does_not_invent_cost`

`cargo test --locked -p summa-api --lib` — 46 passed.
`cargo check --locked -p summa-api --target wasm32-unknown-unknown` — ok.

Squash-merge friendly (one commit). Leaves release-please and Dependency Dashboard #6 alone.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-216bcfa5-e349-49ad-b96f-7fb1ca6c009c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-216bcfa5-e349-49ad-b96f-7fb1ca6c009c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Fail closed when the authentication store is unavailable while keeping analytics usage and costs backed by warehouse data.

Bug Fixes:
- Return sanitized 503 authentication errors when the API key store is unavailable instead of exposing storage failures as 500 responses.
- Keep unauthenticated requests at 401 and preserve generic 500 responses for unrelated failures.

Enhancements:
- Ensure analytics totals are sourced exclusively from warehouse ccusage_events data and do not invent costs.
- Add coverage for sanitized store failures, warehouse query generation, and summary calculations.